### PR TITLE
Fixed large number of conversations / texts in conversations causing issue

### DIFF
--- a/src/main/java/io/github/znetworkw/znpcservers/commands/list/DefaultCommand.java
+++ b/src/main/java/io/github/znetworkw/znpcservers/commands/list/DefaultCommand.java
@@ -36,8 +36,12 @@ public class DefaultCommand extends Command {
     private static final Joiner SPACE_JOINER = Joiner.on(" ");
 
     private static final SkinFunction DO_APPLY_SKIN = (sender, npc, skin) -> NPCSkin.forName(skin, (values, ex) -> {
-        if (ex != null) throw new RuntimeException(ex);
+        if (ex != null) {
+            Configuration.MESSAGES.sendMessage(sender, ConfigurationValue.CANT_GET_SKIN, skin);
+            throw new RuntimeException(ex);
+        }
         npc.changeSkin(NPCSkin.forValues(values));
+        Configuration.MESSAGES.sendMessage(sender, ConfigurationValue.GET_SKIN);
     });
 
     public DefaultCommand() {


### PR DESCRIPTION
If there are more conversations or texts in one conversation than the size inventory, they can not fit in the inventory and thus cause problems.

This commit paginates the main menu and the edit conversation menu.