### PR TITLE
Use persistent NPC UUIDs

### DIFF
--- a/src/main/java/io/github/znetworkw/znpcservers/npc/NPC.java
+++ b/src/main/java/io/github/znetworkw/znpcservers/npc/NPC.java
@@ -44,6 +44,7 @@ public class NPC {
         this.hologram = new Hologram(this);
         this.npcName = NamingType.DEFAULT.resolve(this);
         this.npcSkin = NPCSkin.forValues(npcModel.getSkin(), npcModel.getSignature());
+        this.uuid = npcModel.getUuid();
         if (load)
             onLoad();
     }
@@ -70,7 +71,7 @@ public class NPC {
 
     public void onLoad() {
         if (NPC_MAP.containsKey(getNpcPojo().getId())) throw new IllegalStateException("npc with id " + getNpcPojo().getId() + " already exists.");
-        this.gameProfile = new GameProfile(UUID.randomUUID(), "[ZNPC] " + this.npcName);
+        this.gameProfile = new GameProfile(this.uuid, "[ZNPC] " + this.npcName);
         this.gameProfile.getProperties().put("textures", new Property("textures", this.npcPojo.getSkin(), this.npcPojo.getSignature()));
         changeType(this.npcPojo.getNpcType());
         updateProfile(this.gameProfile.getProperties());
@@ -200,7 +201,9 @@ public class NPC {
     }
 
     public synchronized void spawn(ZUser user) {
-        if (this.viewers.contains(user)) throw new IllegalStateException(user.getUUID().toString() + " is already a viewer.");
+        if (this.viewers.contains(user)) {
+            return;
+        }
         try {
             this.viewers.add(user);
             boolean npcIsPlayer = (this.npcPojo.getNpcType() == NPCType.PLAYER);

--- a/src/main/java/io/github/znetworkw/znpcservers/npc/NPCModel.java
+++ b/src/main/java/io/github/znetworkw/znpcservers/npc/NPCModel.java
@@ -9,9 +9,10 @@ import java.util.*;
 @SuppressWarnings("unused")
 public class NPCModel {
     private int id;
+    private UUID uuid;
     private double hologramHeight;
     private String skin;
-    private String signature = "";
+    private String signature;
     private String pathName;
     private String glowName;
     private ConversationModel conversation;
@@ -24,14 +25,11 @@ public class NPCModel {
     private Map<String, String[]> customizationMap;
 
     public NPCModel(int id) {
-        this();
         this.id = id;
+        this.uuid = UUID.randomUUID();
         this.skin = "";
         this.signature = "";
         this.npcType = NPCType.PLAYER;
-    }
-
-    private NPCModel() {
         this.hologramLines = Collections.singletonList("/znpcs lines");
         this.clickActions = new ArrayList<>();
         this.npcEquip = new HashMap<>();
@@ -51,6 +49,14 @@ public class NPCModel {
     public NPCModel withId(int id) {
         setId(id);
         return this;
+    }
+
+    public UUID getUuid() {
+        return this.uuid;
+    }
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
     }
 
     public double getHologramHeight() {


### PR DESCRIPTION
NPCs will maintain the same UUID between restarts. This should allow other resources (like [Quests](https://github.com/PikaMug/Quests)) to integrate without relying on arbitrary IDs.