### PR TITLE
Spam fix for older versions

### DIFF
--- a/src/main/java/io/github/znetworkw/znpcservers/commands/list/DefaultCommand.java
+++ b/src/main/java/io/github/znetworkw/znpcservers/commands/list/DefaultCommand.java
@@ -84,6 +84,10 @@ public class DefaultCommand extends Command {
             return;
         }
         NPCType npcType = NPCType.valueOf(args.get("type").toUpperCase());
+        if (npcType.getConstructor() == null && !npcType.equals(NPCType.PLAYER)) {
+            Configuration.MESSAGES.sendMessage(sender.getCommandSender(), ConfigurationValue.NOT_SUPPORTED_NPC_TYPE);
+            return;
+        }
         ZNPCsPlus.createNPC(id, npcType, sender.getPlayer().getLocation(), name);
         Configuration.MESSAGES.sendMessage(sender.getCommandSender(), ConfigurationValue.SUCCESS);
     }
@@ -116,7 +120,13 @@ public class DefaultCommand extends Command {
             sender.sendMessage(ChatColor.DARK_GREEN + "NPC list:");
             for (NPCModel npcModel : ConfigurationConstants.NPC_LIST) {
                 List<BaseComponent> parts = new ArrayList<>();
-                String message = "- " + npcModel.getId() + " " + npcModel.getHologramLines().toString() + " (" + npcModel.getLocation().getWorldName() + " " + (int) npcModel.getLocation().getX() + " " + (int) npcModel.getLocation().getY() + " " + (int) npcModel.getLocation().getZ() + ") ";
+                TextComponent component1 = new TextComponent("-");
+                component1.setColor(ChatColor.GREEN);
+                parts.add(component1);
+                TextComponent idComponent = new TextComponent(" " + npcModel.getId());
+                idComponent.setColor(npcModel.getShouldSpawn() ? ChatColor.GREEN : ChatColor.RED);
+                parts.add(idComponent);
+                String message = " " + npcModel.getHologramLines().toString() + " (" + npcModel.getLocation().getWorldName() + " " + (int) npcModel.getLocation().getX() + " " + (int) npcModel.getLocation().getY() + " " + (int) npcModel.getLocation().getZ() + ") ";
                 TextComponent textComponent = new TextComponent(message);
                 textComponent.setColor(ChatColor.GREEN);
                 parts.add(textComponent);

--- a/src/main/java/io/github/znetworkw/znpcservers/configuration/ConfigurationConstants.java
+++ b/src/main/java/io/github/znetworkw/znpcservers/configuration/ConfigurationConstants.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public final class ConfigurationConstants {
     public static final String SPACE_SYMBOL = Configuration.CONFIGURATION.getValue(ConfigurationValue.REPLACE_SYMBOL);
+    public static final boolean DEBUG_ENABLED = Configuration.CONFIGURATION.getValue(ConfigurationValue.DEBUG_ENABLED);
     public static final int VIEW_DISTANCE = Configuration.CONFIGURATION.<Integer>getValue(ConfigurationValue.VIEW_DISTANCE);
     public static final int SAVE_DELAY = Configuration.CONFIGURATION.<Integer>getValue(ConfigurationValue.SAVE_NPCS_DELAY_SECONDS);
     public static final boolean RGB_ANIMATION = Configuration.CONFIGURATION.<Boolean>getValue(ConfigurationValue.ANIMATION_RGB);

--- a/src/main/java/io/github/znetworkw/znpcservers/configuration/ConfigurationValue.java
+++ b/src/main/java/io/github/znetworkw/znpcservers/configuration/ConfigurationValue.java
@@ -51,6 +51,7 @@ public enum ConfigurationValue {
     FETCHING_SKIN("messages", "&aFetching skin for name: &f%s&a. Please wait...", String.class),
     CANT_GET_SKIN("messages", "&cCould not fetch skin for name: %s.", String.class),
     GET_SKIN("messages", "&aSkin successfully fetched!", String.class),
+    NOT_SUPPORTED_NPC_TYPE("messages", "&cThis NPC type doesn't exists or is not supported in your current server version.", String.class),
     CONVERSATION_LIST("conversations" /* Leave this lowercase or it will break */, new ArrayList<>(), Conversation.class);
 
     public static final Map<String, ImmutableSet<ConfigurationValue>> VALUES_BY_NAME;

--- a/src/main/java/io/github/znetworkw/znpcservers/npc/NPCModel.java
+++ b/src/main/java/io/github/znetworkw/znpcservers/npc/NPCModel.java
@@ -19,6 +19,7 @@ public class NPCModel {
     private ConversationModel conversation;
     private ZLocation location;
     private NPCType npcType;
+    private boolean shouldSpawn;
     private List<String> hologramLines;
     private List<NPCAction> clickActions;
     private Map<EquipmentSlot, ItemStack> npcEquip;
@@ -31,6 +32,7 @@ public class NPCModel {
         this.skin = "";
         this.signature = "";
         this.npcType = NPCType.PLAYER;
+        this.shouldSpawn = true;
         this.hologramLines = Collections.singletonList("/znpcs lines");
         this.clickActions = new ArrayList<>();
         this.npcEquip = new HashMap<>();
@@ -175,6 +177,19 @@ public class NPCModel {
 
     public NPCModel withNpcType(NPCType npcType) {
         setNpcType(npcType);
+        return this;
+    }
+
+    public boolean getShouldSpawn() {
+        return this.shouldSpawn;
+    }
+
+    public void setShouldSpawn(boolean shouldSpawn) {
+        this.shouldSpawn = shouldSpawn;
+    }
+
+    public NPCModel withShouldSpawn(boolean shouldSpawn) {
+        setShouldSpawn(shouldSpawn);
         return this;
     }
 


### PR DESCRIPTION
Fixes spam in console if a NPC is loaded in a server that doesn't support it.

For example, the data.json has an NPC with type ALLAY, and this data.json is loaded in a server with version less than 1.19, then there will be spam in console, which is fixed. This also fixes error when deleting these types of NPCs.

Also made DEBUG_ENABLED in config.json work.

`/znpcs list` also shows the ID in red if the NPC is loaded but not spawned as it is not supported.