### PR TITLE
Spawning and saving fixed. Shaking not disabling fix

### DIFF
--- a/plugin/src/main/java/lol/pyr/znpcsplus/metadata/MetadataFactory.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/metadata/MetadataFactory.java
@@ -26,5 +26,5 @@ public interface MetadataFactory {
     Collection<EntityData> name(Component name);
     EntityData noGravity();
     EntityData pose(EntityPose pose);
-    EntityData shaking();
+    EntityData shaking(boolean enabled);
 }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/metadata/V1_17MetadataFactory.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/metadata/V1_17MetadataFactory.java
@@ -15,7 +15,7 @@ public class V1_17MetadataFactory extends V1_16MetadataFactory {
     }
 
     @Override
-    public EntityData shaking() {
-        return newEntityData(7, EntityDataTypes.INT, 140);
+    public EntityData shaking(boolean enabled) {
+        return newEntityData(7, EntityDataTypes.INT, enabled ? 140 : 0);
     }
 }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/metadata/V1_8MetadataFactory.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/metadata/V1_8MetadataFactory.java
@@ -41,7 +41,7 @@ public class V1_8MetadataFactory implements MetadataFactory {
     }
 
     @Override
-    public EntityData shaking() {
+    public EntityData shaking(boolean enabled) {
         throw new UnsupportedOperationException("The shaking entity data isn't supported on this version");
     }
 

--- a/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcRegistryImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcRegistryImpl.java
@@ -136,7 +136,7 @@ public class NpcRegistryImpl implements NpcRegistry {
         if (npcIdLookupMap.containsKey(id)) throw new IllegalArgumentException("An npc with the id " + id + " already exists!");
         NpcImpl npc = new NpcImpl(UUID.randomUUID(), configManager, textSerializer, world, type, location, packetFactory);
         NpcEntryImpl entry = new NpcEntryImpl(id, npc);
-        npcIdLookupMap.put(id, entry);
+        register(entry);
         return entry;
     }
 
@@ -144,7 +144,7 @@ public class NpcRegistryImpl implements NpcRegistry {
     public void delete(String id) {
         id = id.toLowerCase();
         if (!npcIdLookupMap.containsKey(id)) return;
-        npcIdLookupMap.remove(id).getNpc().delete();
+        unregister(npcIdLookupMap.get(id));
     }
 
     public void unload() {

--- a/plugin/src/main/java/lol/pyr/znpcsplus/packets/V1_17PacketFactory.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/packets/V1_17PacketFactory.java
@@ -24,7 +24,7 @@ public class V1_17PacketFactory extends V1_16PacketFactory {
                 properties.hasProperty(propertyRegistry.getByName("glow", Boolean.class)),
                 properties.getProperty(propertyRegistry.getByName("invisible", Boolean.class)),
                 false));
-        if (properties.getProperty(propertyRegistry.getByName("shaking", Boolean.class))) add(data, metadataFactory.shaking());
+        add(data, metadataFactory.shaking(properties.getProperty(propertyRegistry.getByName("shaking", Boolean.class))));
         return data;
     }
 }


### PR DESCRIPTION
Fixes npc not being added to the actual list and thus not spawning or saving.

Fixes npc shaking even after setting the property to false.