### PR TITLE
ConsumerAction for API + fix Importer + addLegacyLine for "&" colors

### DIFF
--- a/api/src/main/java/lol/pyr/znpcsplus/api/interaction/InteractionAction.java
+++ b/api/src/main/java/lol/pyr/znpcsplus/api/interaction/InteractionAction.java
@@ -73,4 +73,8 @@ public abstract class InteractionAction {
      * @param player The player that triggered this interaction
      */
     public abstract void run(Player player);
+
+    public boolean isApiOnly() {
+        return false;
+    }
 }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/ZNpcsPlusApi.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/ZNpcsPlusApi.java
@@ -43,4 +43,6 @@ public class ZNpcsPlusApi implements NpcApi {
     public SkinDescriptorFactory getSkinDescriptorFactory() {
         return skinDescriptorFactory;
     }
+
+
 }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/conversion/znpcs/ZNpcImporter.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/conversion/znpcs/ZNpcImporter.java
@@ -30,10 +30,7 @@ import lol.pyr.znpcsplus.skin.cache.MojangSkinCache;
 import lol.pyr.znpcsplus.skin.descriptor.FetchingDescriptor;
 import lol.pyr.znpcsplus.skin.descriptor.MirrorDescriptor;
 import lol.pyr.znpcsplus.skin.descriptor.PrefetchedDescriptor;
-import lol.pyr.znpcsplus.util.BungeeConnector;
-import lol.pyr.znpcsplus.util.ItemSerializationUtil;
-import lol.pyr.znpcsplus.util.LookType;
-import lol.pyr.znpcsplus.util.NpcLocation;
+import lol.pyr.znpcsplus.util.*;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -143,9 +140,9 @@ public class ZNpcImporter implements DataImporter {
                 }
                 if (toggleValues.containsKey("glow")) {
                     try {
-                        npc.setProperty(propertyRegistry.getByName("glow", DyeColor.class), DyeColor.valueOf((String) toggleValues.get("glow")));
+                        npc.setProperty(propertyRegistry.getByName("glow", NamedColor.class), NamedColor.valueOf((String) toggleValues.get("glow")));
                     } catch (IllegalArgumentException e) {
-                        npc.setProperty(propertyRegistry.getByName("glow", DyeColor.class), DyeColor.WHITE);
+                        npc.setProperty(propertyRegistry.getByName("glow", NamedColor.class), NamedColor.WHITE);
                     }
                 }
             }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramImpl.java
@@ -44,6 +44,10 @@ public class HologramImpl extends Viewable implements Hologram {
         for (Player viewer : getViewers()) newLine.show(viewer.getPlayer());
     }
 
+    public void addLegacyTextLine(String line) {
+        addTextLineComponent(Component.text(line));
+    }
+
     public void addTextLine(String line) {
         addTextLineComponent(textSerializer.deserialize(textSerializer.serialize(MiniMessage.miniMessage().deserialize(line))));
     }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramImpl.java
@@ -10,7 +10,9 @@ import lol.pyr.znpcsplus.util.NpcLocation;
 import lol.pyr.znpcsplus.util.Viewable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.internal.parser.ParsingExceptionImpl;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
@@ -44,12 +46,12 @@ public class HologramImpl extends Viewable implements Hologram {
         for (Player viewer : getViewers()) newLine.show(viewer.getPlayer());
     }
 
-    public void addLegacyTextLine(String line) {
-        addTextLineComponent(Component.text(line));
-    }
-
     public void addTextLine(String line) {
-        addTextLineComponent(textSerializer.deserialize(textSerializer.serialize(MiniMessage.miniMessage().deserialize(line))));
+        try {
+            addTextLineComponent(textSerializer.deserialize(textSerializer.serialize(MiniMessage.miniMessage().deserialize(line))));
+        } catch (ParsingExceptionImpl e) {
+            addTextLineComponent(Component.text(line));
+        }
     }
 
     public void addItemLineStack(org.bukkit.inventory.ItemStack item) {

--- a/plugin/src/main/java/lol/pyr/znpcsplus/interaction/ActionRegistry.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/interaction/ActionRegistry.java
@@ -61,6 +61,7 @@ public class ActionRegistry {
 
     @SuppressWarnings("unchecked")
     public <T extends InteractionAction> String serialize(T action) {
+        if (action.isApiOnly()) return null;
         InteractionActionType<T> serializer = (InteractionActionType<T>) serializerMap.get(action.getClass());
         if (serializer == null) return null;
         return action.getClass().getName() + ";" + serializer.serialize(action);

--- a/plugin/src/main/java/lol/pyr/znpcsplus/interaction/consumer/ConsumerAction.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/interaction/consumer/ConsumerAction.java
@@ -1,0 +1,57 @@
+package lol.pyr.znpcsplus.interaction.consumer;
+
+import lol.pyr.director.adventure.command.CommandContext;
+import lol.pyr.znpcsplus.api.interaction.InteractionType;
+import lol.pyr.znpcsplus.interaction.InteractionActionImpl;
+import lol.pyr.znpcsplus.scheduling.TaskScheduler;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+public class ConsumerAction extends InteractionActionImpl {
+    private final TaskScheduler scheduler;
+    private final Consumer<Player> clickConsumer;
+    private final ConsumerType consumerType;
+
+    public ConsumerAction(TaskScheduler scheduler, Consumer<Player> clickConsumer, ConsumerType consumerType, InteractionType interactionType, long cooldown, long delay) {
+        super(cooldown, delay, interactionType);
+        this.scheduler = scheduler;
+        this.clickConsumer = clickConsumer;
+        this.consumerType = consumerType;
+    }
+
+    public ConsumerAction(TaskScheduler scheduler, Consumer<Player> clickConsumer, InteractionType interactionType, long cooldown, long delay) {
+        this(scheduler, clickConsumer, ConsumerType.SYNC, interactionType, cooldown, delay);
+    }
+
+    @Override
+    public void run(Player player) {
+        this.consumerType.getClickConsumer().accept(scheduler, () -> this.clickConsumer.accept(player));
+    }
+
+    @Override
+    public Component getInfo(String id, int index, CommandContext context) {
+        return Component.text(index + ") ", NamedTextColor.GOLD)
+                .append(Component.text("API Consumer Action (Immutable)", NamedTextColor.DARK_GREEN));
+    }
+
+    public Consumer<Player> getClickConsumer() {
+        return clickConsumer;
+    }
+
+    public enum ConsumerType {
+        SYNC(TaskScheduler::runSyncGlobal),
+        ASYNC(TaskScheduler::runAsyncGlobal);
+        private final BiConsumer<TaskScheduler, Runnable> clickConsumer;
+
+        ConsumerType(BiConsumer<TaskScheduler, Runnable> clickConsumer) {
+            this.clickConsumer = clickConsumer;
+        }
+
+        public BiConsumer<TaskScheduler, Runnable> getClickConsumer() {
+            return clickConsumer;
+        }
+    }
+}

--- a/plugin/src/main/java/lol/pyr/znpcsplus/interaction/consumer/ConsumerAction.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/interaction/consumer/ConsumerAction.java
@@ -27,6 +27,11 @@ public class ConsumerAction extends InteractionActionImpl {
     }
 
     @Override
+    public boolean isApiOnly() {
+        return true;
+    }
+
+    @Override
     public void run(Player player) {
         this.consumerType.getClickConsumer().accept(scheduler, () -> this.clickConsumer.accept(player));
     }


### PR DESCRIPTION
Why is there no ConsumerAction in API?

addTextLine broken with "§" symbol. (Legacy formatting codes have been detected in a MiniMessage string - this is unsupported behaviour. Please refer to the Adventure documentation (https://docs.adventure.kyori.net) for more information.)