### PR TITLE
Fix MiniMessages doesn't parse correctly when people uses holo set command instead of add.

### DIFF
--- a/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramImpl.java
@@ -106,7 +106,7 @@ public class HologramImpl extends Viewable implements Hologram {
     }
 
     public void insertTextLine(int index, String line) {
-        insertTextLineComponent(index, textSerializer.deserialize(line));
+        insertTextLineComponent(index, textSerializer.deserialize(textSerializer.serialize(MiniMessage.miniMessage().deserialize(line))));
     }
 
     public void insertItemLineStack(int index, org.bukkit.inventory.ItemStack item) {


### PR DESCRIPTION
Fixes: #120 