### PR TITLE
fix: update checker timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Open an issue in the GitHub [issue tracker](https://github.com/Pyrbu/ZNPCsPlus/i
 - [wiki.vg](https://wiki.vg/Main_Page) - Minecraft protocol documentation
 - [gson](https://github.com/google/gson) - JSON parsing library made by Google
 - [Mineskin.org](https://mineskin.org/) - Website for raw skin file uploads
-- [SpigotResourcesAPI](https://github.com/robertlit/SpigotResourcesAPI/) - Spigot API wrapper used for updater
 - [adventure](https://docs.advntr.dev/) - Minecraft text api
 - [DazzleConf](https://github.com/A248/DazzleConf) - Configuration library
 - [Director](https://github.com/Pyrbu/Director) - Command library

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -19,7 +19,6 @@ dependencies {
     compileOnly "me.clip:placeholderapi:2.11.6" // Placeholder support
     implementation "com.google.code.gson:gson:2.10.1" // JSON parsing
     implementation "org.bstats:bstats-bukkit:3.0.2" // Plugin stats
-    implementation "me.robertlit:SpigotResourcesAPI:2.0" // Spigot API wrapper for update checker
     implementation "com.github.retrooper:packetevents-spigot:2.4.0" // Packets
     implementation "space.arim.dazzleconf:dazzleconf-ext-snakeyaml:1.2.1" // Configs
     implementation "lol.pyr:director-adventure:2.1.2" // Commands
@@ -40,7 +39,6 @@ shadowJar {
 
     // When changing anything here remember to also update the bootstrap
     relocate "org.bstats", "lol.pyr.znpcsplus.libraries.bstats"
-    relocate "me.robertlit.spigotresources", "lol.pyr.znpcsplus.libraries.spigotresources"
     relocate "net.kyori", "lol.pyr.znpcsplus.libraries.kyori"
     relocate "org.checkerframework", "lol.pyr.znpcsplus.libraries.checkerframework"
     relocate "com.google", "lol.pyr.znpcsplus.libraries.google"

--- a/plugin/src/main/java/lol/pyr/znpcsplus/updater/UpdateChecker.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/updater/UpdateChecker.java
@@ -1,19 +1,20 @@
 package lol.pyr.znpcsplus.updater;
 
-import me.robertlit.spigotresources.api.Resource;
-import me.robertlit.spigotresources.api.SpigotResourcesAPI;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.scheduler.BukkitRunnable;
 
-import java.util.concurrent.TimeUnit;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.logging.Logger;
 
 public class UpdateChecker extends BukkitRunnable {
     private final static Logger logger = Logger.getLogger("ZNPCsPlus Update Checker");
-    private final static int RESOURCE_ID = 109380;
+    private static final String GET_RESOURCE = "https://api.spigotmc.org/simple/0.2/index.php?action=getResource&id=109380";
     public final static String DOWNLOAD_LINK = "https://www.spigotmc.org/resources/znpcsplus.109380/";
-
-    private final SpigotResourcesAPI api = new SpigotResourcesAPI(1, TimeUnit.MINUTES);
 
     private final PluginDescriptionFile info;
     private Status status = Status.UNKNOWN;
@@ -24,9 +25,29 @@ public class UpdateChecker extends BukkitRunnable {
     }
 
     public void run() {
-        Resource resource = api.getResource(RESOURCE_ID).join();
-        if (resource == null) return;
-        newestVersion = resource.getVersion();
+        String foundVersion = null;
+        try {
+            URL getResource = new URL(GET_RESOURCE);
+            HttpURLConnection httpRequest = ((HttpURLConnection) getResource.openConnection());
+            httpRequest.setRequestMethod("GET");
+            httpRequest.setConnectTimeout(5_000);
+            httpRequest.setReadTimeout(5_000);
+
+            if (httpRequest.getResponseCode() == HttpURLConnection.HTTP_OK) {
+                try (InputStreamReader reader = new InputStreamReader(httpRequest.getInputStream())) {
+                    JsonObject jsonObject = JsonParser.parseReader(reader).getAsJsonObject();
+                    foundVersion = jsonObject.get("current_version").getAsString();
+                }
+            } else {
+                logger.warning("Failed to check for updates: HTTP response code " + httpRequest.getResponseCode());
+            }
+        } catch (IOException e) {
+            logger.warning("Failed to check for updates: " + e.getMessage());
+            return;
+        }
+
+        if (foundVersion == null) return;
+        newestVersion = foundVersion;
 
         status = compareVersions(info.getVersion(), newestVersion);
         if (status == Status.UPDATE_NEEDED) notifyConsole();

--- a/plugin/src/main/java/lol/pyr/znpcsplus/updater/UpdateChecker.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/updater/UpdateChecker.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
 
 public class UpdateChecker extends BukkitRunnable {
     private final static Logger logger = Logger.getLogger("ZNPCsPlus Update Checker");
-    private static final String GET_RESOURCE = "https://api.spigotmc.org/simple/0.2/index.php?action=getResource&id=109380";
+    private final static String GET_RESOURCE = "https://api.spigotmc.org/simple/0.2/index.php?action=getResource&id=109380";
     public final static String DOWNLOAD_LINK = "https://www.spigotmc.org/resources/znpcsplus.109380/";
 
     private final PluginDescriptionFile info;


### PR DESCRIPTION
Had an interesting crash where the server hit process limits, and the update checker (among other things), stood out to me, with ~150 indefinitely blocked threads

This PR removes robertlit/SpigotResourcesAPI and replaces its functionality with a direct http request, configured with a timeout

![image](https://github.com/user-attachments/assets/1e31f314-5c91-4f1d-8a22-5b4275939737)
