### PR TITLE
Enhancements: Sitting Entities, Creaking NPCs, and Updated PacketEvents

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compileOnly "me.clip:placeholderapi:2.11.6" // Placeholder support
     implementation "com.google.code.gson:gson:2.10.1" // JSON parsing
     implementation "org.bstats:bstats-bukkit:3.0.2" // Plugin stats
-    implementation "com.github.retrooper:packetevents-spigot:2.6.0" // Packets
+    implementation "com.github.retrooper:packetevents-spigot:2.7.0" // Packets
     implementation "space.arim.dazzleconf:dazzleconf-ext-snakeyaml:1.2.1" // Configs
     implementation "lol.pyr:director-adventure:2.1.2" // Commands
 

--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/ArmorStandVehicleEntity.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/ArmorStandVehicleEntity.java
@@ -1,0 +1,72 @@
+package lol.pyr.znpcsplus.entity;
+
+import io.github.retrooper.packetevents.util.SpigotConversionUtil;
+import lol.pyr.znpcsplus.api.entity.EntityProperty;
+import lol.pyr.znpcsplus.api.entity.PropertyHolder;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Represents an armor stand vehicle entity.
+ * <p>
+ *     This entity is used to make the NPC sit on an invisible armor stand.
+ * </p>
+ */
+public class ArmorStandVehicleEntity implements PropertyHolder {
+
+    private final Map<EntityPropertyImpl<?>, Object> propertyMap = new HashMap<>();
+
+    public ArmorStandVehicleEntity(EntityPropertyRegistryImpl propertyRegistry) {
+        setProperty(propertyRegistry.getByName("small", Boolean.class), true);
+        setProperty(propertyRegistry.getByName("invisible", Boolean.class), true);
+        setProperty(propertyRegistry.getByName("base_plate", Boolean.class), false);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getProperty(EntityProperty<T> key) {
+        return hasProperty(key) ? (T) propertyMap.get((EntityPropertyImpl<?>) key) : key.getDefaultValue();
+    }
+
+    @Override
+    public boolean hasProperty(EntityProperty<?> key) {
+        return propertyMap.containsKey((EntityPropertyImpl<?>) key);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> void setProperty(EntityProperty<T> key, T value) {
+        Object val = value;
+        if (val instanceof ItemStack) val = SpigotConversionUtil.fromBukkitItemStack((ItemStack) val);
+
+        setProperty((EntityPropertyImpl<T>) key, (T) val);
+    }
+
+    @Override
+    public void setItemProperty(EntityProperty<?> key, ItemStack value) {
+        throw new UnsupportedOperationException("Cannot set item properties on armor stands");
+    }
+
+    @Override
+    public ItemStack getItemProperty(EntityProperty<?> key) {
+        throw new UnsupportedOperationException("Cannot get item properties on armor stands");
+    }
+
+    public <T> void setProperty(EntityPropertyImpl<T> key, T value) {
+        if (key == null) return;
+        if (value == null || value.equals(key.getDefaultValue())) propertyMap.remove(key);
+        else propertyMap.put(key, value);
+    }
+
+    public Set<EntityProperty<?>> getAllProperties() {
+        return Collections.unmodifiableSet(propertyMap.keySet());
+    }
+
+    @Override
+    public Set<EntityProperty<?>> getAppliedProperties() {
+        return Collections.unmodifiableSet(propertyMap.keySet());
+    }
+}

--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/ArmorStandVehicleEntity.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/ArmorStandVehicleEntity.java
@@ -21,9 +21,9 @@ public class ArmorStandVehicleEntity implements PropertyHolder {
     private final Map<EntityPropertyImpl<?>, Object> propertyMap = new HashMap<>();
 
     public ArmorStandVehicleEntity(EntityPropertyRegistryImpl propertyRegistry) {
-        setProperty(propertyRegistry.getByName("small", Boolean.class), true);
-        setProperty(propertyRegistry.getByName("invisible", Boolean.class), true);
-        setProperty(propertyRegistry.getByName("base_plate", Boolean.class), false);
+        _setProperty(propertyRegistry.getByName("small", Boolean.class), true);
+        _setProperty(propertyRegistry.getByName("invisible", Boolean.class), true);
+        _setProperty(propertyRegistry.getByName("base_plate", Boolean.class), false);
     }
 
     @SuppressWarnings("unchecked")
@@ -37,12 +37,16 @@ public class ArmorStandVehicleEntity implements PropertyHolder {
     }
 
     @SuppressWarnings("unchecked")
-    @Override
-    public <T> void setProperty(EntityProperty<T> key, T value) {
+    private <T> void _setProperty(EntityProperty<T> key, T value) {
         Object val = value;
         if (val instanceof ItemStack) val = SpigotConversionUtil.fromBukkitItemStack((ItemStack) val);
 
         setProperty((EntityPropertyImpl<T>) key, (T) val);
+    }
+
+    @Override
+    public <T> void setProperty(EntityProperty<T> key, T value) {
+        throw new UnsupportedOperationException("Cannot set properties on armor stands");
     }
 
     @Override

--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/ArmorStandVehicleProperties.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/ArmorStandVehicleProperties.java
@@ -16,11 +16,11 @@ import java.util.Set;
  *     This entity is used to make the NPC sit on an invisible armor stand.
  * </p>
  */
-public class ArmorStandVehicleEntity implements PropertyHolder {
+public class ArmorStandVehicleProperties implements PropertyHolder {
 
     private final Map<EntityPropertyImpl<?>, Object> propertyMap = new HashMap<>();
 
-    public ArmorStandVehicleEntity(EntityPropertyRegistryImpl propertyRegistry) {
+    public ArmorStandVehicleProperties(EntityPropertyRegistryImpl propertyRegistry) {
         _setProperty(propertyRegistry.getByName("small", Boolean.class), true);
         _setProperty(propertyRegistry.getByName("invisible", Boolean.class), true);
         _setProperty(propertyRegistry.getByName("base_plate", Boolean.class), false);

--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/EntityPropertyRegistryImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/EntityPropertyRegistryImpl.java
@@ -182,6 +182,8 @@ public class EntityPropertyRegistryImpl implements EntityPropertyRegistry {
             register(new BooleanProperty("baby", babyIndex, false, legacyBooleans));
         }
 
+        register(new EntitySittingProperty(packetFactory, this));
+
         // Player
         register(new DummyProperty<>("skin", SkinDescriptor.class, false));
         final int skinLayersIndex;

--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/EntityPropertyRegistryImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/EntityPropertyRegistryImpl.java
@@ -667,6 +667,16 @@ public class EntityPropertyRegistryImpl implements EntityPropertyRegistry {
 
         // Bogged
         register(new BooleanProperty("bogged_sheared", 16, false, legacyBooleans));
+
+        if (!ver.isNewerThanOrEquals(ServerVersion.V_1_21_2)) return;
+
+        // Creaking
+        register(new BooleanProperty("creaking_active", 17, false, legacyBooleans));
+
+        if (!ver.isNewerThanOrEquals(ServerVersion.V_1_21_4)) return;
+
+        // Creaking
+        register(new BooleanProperty("creaking_crumbling", 18, false, legacyBooleans));
     }
 
     private void registerSerializer(PropertySerializer<?> serializer) {

--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/PacketEntity.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/PacketEntity.java
@@ -4,6 +4,7 @@ import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
+import lol.pyr.znpcsplus.ZNpcsPlusBootstrap;
 import lol.pyr.znpcsplus.api.entity.EntityProperty;
 import lol.pyr.znpcsplus.api.entity.PropertyHolder;
 import lol.pyr.znpcsplus.packets.PacketFactory;
@@ -13,6 +14,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.UUID;
 
@@ -25,6 +27,8 @@ public class PacketEntity implements PropertyHolder {
 
     private final EntityType type;
     private NpcLocation location;
+
+    private final HashMap<String, Object> metadata = new HashMap<>();
 
     public PacketEntity(PacketFactory packetFactory, PropertyHolder properties, EntityType type, NpcLocation location) {
         this.packetFactory = packetFactory;
@@ -67,6 +71,15 @@ public class PacketEntity implements PropertyHolder {
 
     public void despawn(Player player) {
         packetFactory.destroyEntity(player, this, properties);
+        if (hasMetadata("ridingVehicle")) {
+            try {
+                PacketEntity armorStand = (PacketEntity) getMetadata("ridingVehicle");
+                armorStand.despawn(player);
+            } catch (Exception e) {
+                //noinspection CallToPrintStackTrace
+                e.printStackTrace();
+            }
+        }
     }
 
     public void refreshMeta(Player player) {
@@ -115,5 +128,33 @@ public class PacketEntity implements PropertyHolder {
     @Override
     public Set<EntityProperty<?>> getAppliedProperties() {
         return properties.getAppliedProperties();
+    }
+
+    public void setMetadata(String key, Object value) {
+        metadata.put(key, value);
+    }
+
+    public Object getMetadata(String key) {
+        return metadata.get(key);
+    }
+
+    public <T> T getMetadata(String key, Class<T> type) {
+        try {
+            return type.cast(metadata.get(key));
+        } catch (ClassCastException e) {
+            return null;
+        }
+    }
+
+    public void removeMetadata(String key) {
+        metadata.remove(key);
+    }
+
+    public boolean hasMetadata(String key) {
+        return metadata.containsKey(key);
+    }
+
+    public void clearMetadata() {
+        metadata.clear();
     }
 }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/PacketEntity.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/PacketEntity.java
@@ -4,17 +4,15 @@ import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
-import lol.pyr.znpcsplus.ZNpcsPlusBootstrap;
 import lol.pyr.znpcsplus.api.entity.EntityProperty;
 import lol.pyr.znpcsplus.api.entity.PropertyHolder;
 import lol.pyr.znpcsplus.packets.PacketFactory;
 import lol.pyr.znpcsplus.reflection.Reflections;
 import lol.pyr.znpcsplus.util.NpcLocation;
+import lol.pyr.znpcsplus.util.Viewable;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Set;
 import java.util.UUID;
 
@@ -22,17 +20,19 @@ public class PacketEntity implements PropertyHolder {
     private final PacketFactory packetFactory;
 
     private final PropertyHolder properties;
+    private final Viewable viewable;
     private final int entityId;
     private final UUID uuid;
 
     private final EntityType type;
     private NpcLocation location;
 
-    private final HashMap<String, Object> metadata = new HashMap<>();
+    private PacketEntity vehicle;
 
-    public PacketEntity(PacketFactory packetFactory, PropertyHolder properties, EntityType type, NpcLocation location) {
+    public PacketEntity(PacketFactory packetFactory, PropertyHolder properties, Viewable viewable, EntityType type, NpcLocation location) {
         this.packetFactory = packetFactory;
         this.properties = properties;
+        this.viewable = viewable;
         this.entityId = reserveEntityID();
         this.uuid = UUID.randomUUID();
         this.type = type;
@@ -55,31 +55,59 @@ public class PacketEntity implements PropertyHolder {
         return type;
     }
 
-    public void setLocation(NpcLocation location, Collection<Player> viewers) {
+    public void setLocation(NpcLocation location) {
         this.location = location;
-        for (Player viewer : viewers) packetFactory.teleportEntity(viewer, this);
+        if (vehicle != null) {
+            vehicle.setLocation(location.withY(location.getY() - 0.9));
+            return;
+        }
+        for (Player viewer : viewable.getViewers()) packetFactory.teleportEntity(viewer, this);
     }
 
     public void spawn(Player player) {
         if (type == EntityTypes.PLAYER) packetFactory.spawnPlayer(player, this, properties);
         else packetFactory.spawnEntity(player, this, properties);
+        if (vehicle != null) {
+            vehicle.spawn(player);
+            packetFactory.setPassenger(player, vehicle, this);
+        }
     }
 
     public void setHeadRotation(Player player, float yaw, float pitch) {
         packetFactory.sendHeadRotation(player, this, yaw, pitch);
     }
 
-    public void despawn(Player player) {
-        packetFactory.destroyEntity(player, this, properties);
-        if (hasMetadata("ridingVehicle")) {
-            try {
-                PacketEntity armorStand = (PacketEntity) getMetadata("ridingVehicle");
-                armorStand.despawn(player);
-            } catch (Exception e) {
-                //noinspection CallToPrintStackTrace
-                e.printStackTrace();
+    public PacketEntity getVehicle() {
+        return vehicle;
+    }
+
+    public Viewable getViewable() {
+        return viewable;
+    }
+
+    public void setVehicle(PacketEntity vehicle) {
+        // remove old vehicle
+        if (this.vehicle != null) {
+            for (Player player : viewable.getViewers()) {
+                packetFactory.setPassenger(player, this.vehicle, null);
+                this.vehicle.despawn(player);
+                packetFactory.teleportEntity(player, this);
             }
         }
+
+        this.vehicle = vehicle;
+        if (this.vehicle == null) return;
+
+        vehicle.setLocation(location.withY(location.getY() - 0.9));
+        for (Player player : viewable.getViewers()) {
+            vehicle.spawn(player);
+            packetFactory.setPassenger(player, vehicle, this);
+        }
+    }
+
+    public void despawn(Player player) {
+        packetFactory.destroyEntity(player, this, properties);
+        if (vehicle != null) vehicle.despawn(player);
     }
 
     public void refreshMeta(Player player) {
@@ -128,33 +156,5 @@ public class PacketEntity implements PropertyHolder {
     @Override
     public Set<EntityProperty<?>> getAppliedProperties() {
         return properties.getAppliedProperties();
-    }
-
-    public void setMetadata(String key, Object value) {
-        metadata.put(key, value);
-    }
-
-    public Object getMetadata(String key) {
-        return metadata.get(key);
-    }
-
-    public <T> T getMetadata(String key, Class<T> type) {
-        try {
-            return type.cast(metadata.get(key));
-        } catch (ClassCastException e) {
-            return null;
-        }
-    }
-
-    public void removeMetadata(String key) {
-        metadata.remove(key);
-    }
-
-    public boolean hasMetadata(String key) {
-        return metadata.containsKey(key);
-    }
-
-    public void clearMetadata() {
-        metadata.clear();
     }
 }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/properties/EntitySittingProperty.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/properties/EntitySittingProperty.java
@@ -24,10 +24,12 @@ public class EntitySittingProperty extends EntityPropertyImpl<Boolean> {
     @Override
     public void apply(Player player, PacketEntity entity, boolean isSpawned, Map<Integer, EntityData> properties) {
         boolean sitting = entity.getProperty(this);
-        if (sitting) if (entity.getVehicle() == null) {
-            PacketEntity vehiclePacketEntity = new PacketEntity(packetFactory, new ArmorStandVehicleProperties(propertyRegistry),
-                    entity.getViewable(), EntityTypes.ARMOR_STAND, entity.getLocation().withY(entity.getLocation().getY() - 0.9));
-            entity.setVehicle(vehiclePacketEntity);
+        if (sitting) {
+            if (entity.getVehicle() == null) {
+                PacketEntity vehiclePacketEntity = new PacketEntity(packetFactory, new ArmorStandVehicleProperties(propertyRegistry),
+                        entity.getViewable(), EntityTypes.ARMOR_STAND, entity.getLocation().withY(entity.getLocation().getY() - 0.9));
+                entity.setVehicle(vehiclePacketEntity);
+            }
         } else if (entity.getVehicle() != null) {
             entity.setVehicle(null);
         }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/properties/EntitySittingProperty.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/properties/EntitySittingProperty.java
@@ -1,0 +1,53 @@
+package lol.pyr.znpcsplus.entity.properties;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
+import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetPassengers;
+import lol.pyr.znpcsplus.entity.ArmorStandVehicleEntity;
+import lol.pyr.znpcsplus.entity.EntityPropertyImpl;
+import lol.pyr.znpcsplus.entity.EntityPropertyRegistryImpl;
+import lol.pyr.znpcsplus.entity.PacketEntity;
+import lol.pyr.znpcsplus.packets.PacketFactory;
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+
+public class EntitySittingProperty extends EntityPropertyImpl<Boolean> {
+    private final PacketFactory packetFactory;
+    private final EntityPropertyRegistryImpl propertyRegistry;
+
+    public EntitySittingProperty(PacketFactory packetFactory, EntityPropertyRegistryImpl propertyRegistry) {
+        super("entity_sitting", false, Boolean.class);
+        this.packetFactory = packetFactory;
+        this.propertyRegistry = propertyRegistry;
+    }
+
+    @Override
+    public void apply(Player player, PacketEntity entity, boolean isSpawned, Map<Integer, EntityData> properties) {
+        boolean sitting = entity.getProperty(this);
+        if (sitting) {
+            ArmorStandVehicleEntity vehicleEntity = new ArmorStandVehicleEntity(propertyRegistry);
+            PacketEntity vehiclePacketEntity = new PacketEntity(packetFactory, vehicleEntity, EntityTypes.ARMOR_STAND, entity.getLocation().withY(entity.getLocation().getY() - 0.9));
+            vehiclePacketEntity.spawn(player);
+            entity.setMetadata("ridingVehicle", vehiclePacketEntity);
+            PacketEvents.getAPI().getPlayerManager().sendPacket(player, new WrapperPlayServerSetPassengers(
+                    vehiclePacketEntity.getEntityId(),
+                    new int[]{entity.getEntityId()}
+            ));
+        } else {
+            if (entity.hasMetadata("ridingVehicle")) {
+                PacketEntity vehicleEntity = (PacketEntity) entity.getMetadata("ridingVehicle");
+                PacketEvents.getAPI().getPlayerManager().sendPacket(player, new WrapperPlayServerSetPassengers(
+                        vehicleEntity.getEntityId(),
+                        new int[]{}
+                ));
+                vehicleEntity.despawn(player);
+                entity.removeMetadata("ridingVehicle");
+                // Send a packet to reset the npc's position
+                packetFactory.teleportEntity(player, entity);
+            }
+        }
+    }
+
+}

--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/properties/EntitySittingProperty.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/properties/EntitySittingProperty.java
@@ -1,10 +1,8 @@
 package lol.pyr.znpcsplus.entity.properties;
 
-import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetPassengers;
-import lol.pyr.znpcsplus.entity.ArmorStandVehicleEntity;
+import lol.pyr.znpcsplus.entity.ArmorStandVehicleProperties;
 import lol.pyr.znpcsplus.entity.EntityPropertyImpl;
 import lol.pyr.znpcsplus.entity.EntityPropertyRegistryImpl;
 import lol.pyr.znpcsplus.entity.PacketEntity;
@@ -26,28 +24,12 @@ public class EntitySittingProperty extends EntityPropertyImpl<Boolean> {
     @Override
     public void apply(Player player, PacketEntity entity, boolean isSpawned, Map<Integer, EntityData> properties) {
         boolean sitting = entity.getProperty(this);
-        if (sitting) {
-            ArmorStandVehicleEntity vehicleEntity = new ArmorStandVehicleEntity(propertyRegistry);
-            PacketEntity vehiclePacketEntity = new PacketEntity(packetFactory, vehicleEntity, EntityTypes.ARMOR_STAND, entity.getLocation().withY(entity.getLocation().getY() - 0.9));
-            vehiclePacketEntity.spawn(player);
-            entity.setMetadata("ridingVehicle", vehiclePacketEntity);
-            PacketEvents.getAPI().getPlayerManager().sendPacket(player, new WrapperPlayServerSetPassengers(
-                    vehiclePacketEntity.getEntityId(),
-                    new int[]{entity.getEntityId()}
-            ));
-        } else {
-            if (entity.hasMetadata("ridingVehicle")) {
-                PacketEntity vehicleEntity = (PacketEntity) entity.getMetadata("ridingVehicle");
-                PacketEvents.getAPI().getPlayerManager().sendPacket(player, new WrapperPlayServerSetPassengers(
-                        vehicleEntity.getEntityId(),
-                        new int[]{}
-                ));
-                vehicleEntity.despawn(player);
-                entity.removeMetadata("ridingVehicle");
-                // Send a packet to reset the npc's position
-                packetFactory.teleportEntity(player, entity);
-            }
+        if (sitting) if (entity.getVehicle() == null) {
+            PacketEntity vehiclePacketEntity = new PacketEntity(packetFactory, new ArmorStandVehicleProperties(propertyRegistry),
+                    entity.getViewable(), EntityTypes.ARMOR_STAND, entity.getLocation().withY(entity.getLocation().getY() - 0.9));
+            entity.setVehicle(vehiclePacketEntity);
+        } else if (entity.getVehicle() != null) {
+            entity.setVehicle(null);
         }
     }
-
 }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramImpl.java
@@ -38,9 +38,9 @@ public class HologramImpl extends Viewable implements Hologram {
     }
 
     public void addTextLineComponent(Component line) {
-        HologramText newLine = new HologramText(propertyRegistry, packetFactory, null, line);
+        HologramText newLine = new HologramText(this, propertyRegistry, packetFactory, null, line);
         lines.add(newLine);
-        relocateLines(newLine);
+        relocateLines();
         for (Player viewer : getViewers()) newLine.show(viewer.getPlayer());
     }
 
@@ -57,9 +57,9 @@ public class HologramImpl extends Viewable implements Hologram {
     }
 
     public void addItemLinePEStack(ItemStack item) {
-        HologramItem newLine = new HologramItem(propertyRegistry, packetFactory, null, item);
+        HologramItem newLine = new HologramItem(this, propertyRegistry, packetFactory, null, item);
         lines.add(newLine);
-        relocateLines(newLine);
+        relocateLines();
         for (Player viewer : getViewers()) newLine.show(viewer.getPlayer());
     }
 
@@ -99,9 +99,9 @@ public class HologramImpl extends Viewable implements Hologram {
     }
 
     public void insertTextLineComponent(int index, Component line) {
-        HologramText newLine = new HologramText(propertyRegistry, packetFactory, null, line);
+        HologramText newLine = new HologramText(this, propertyRegistry, packetFactory, null, line);
         lines.add(index, newLine);
-        relocateLines(newLine);
+        relocateLines();
         for (Player viewer : getViewers()) newLine.show(viewer.getPlayer());
     }
 
@@ -114,9 +114,9 @@ public class HologramImpl extends Viewable implements Hologram {
     }
 
     public void insertItemLinePEStack(int index, ItemStack item) {
-        HologramItem newLine = new HologramItem(propertyRegistry, packetFactory, null, item);
+        HologramItem newLine = new HologramItem(this, propertyRegistry, packetFactory, null, item);
         lines.add(index, newLine);
-        relocateLines(newLine);
+        relocateLines();
         for (Player viewer : getViewers()) newLine.show(viewer.getPlayer());
     }
 
@@ -172,14 +172,10 @@ public class HologramImpl extends Viewable implements Hologram {
     }
 
     private void relocateLines() {
-        relocateLines(null);
-    }
-
-    private void relocateLines(HologramLine<?> newLine) {
         final double lineSpacing = configManager.getConfig().lineSpacing();
         double height = location.getY() + (lines.size() - 1) * lineSpacing + getOffset();
         for (HologramLine<?> line : lines) {
-            line.setLocation(location.withY(height), line == newLine ? Collections.emptySet() : getViewers());
+            line.setLocation(location.withY(height));
             height -= lineSpacing;
         }
     }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramItem.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramItem.java
@@ -15,13 +15,11 @@ import lol.pyr.znpcsplus.api.entity.EntityProperty;
 import lol.pyr.znpcsplus.entity.EntityPropertyRegistryImpl;
 import lol.pyr.znpcsplus.packets.PacketFactory;
 import lol.pyr.znpcsplus.util.NpcLocation;
-import org.bukkit.entity.Player;
-
-import java.util.Collection;
+import lol.pyr.znpcsplus.util.Viewable;
 
 public class HologramItem extends HologramLine<ItemStack> {
-    public HologramItem(EntityPropertyRegistryImpl propertyRegistry, PacketFactory packetFactory, NpcLocation location, ItemStack item) {
-        super(item, packetFactory, EntityTypes.ITEM, location);
+    public HologramItem(Viewable viewable,  EntityPropertyRegistryImpl propertyRegistry, PacketFactory packetFactory, NpcLocation location, ItemStack item) {
+        super(viewable, item, packetFactory, EntityTypes.ITEM, location);
         addProperty(propertyRegistry.getByName("holo_item"));
     }
 
@@ -33,8 +31,8 @@ public class HologramItem extends HologramLine<ItemStack> {
     }
 
     @Override
-    public void setLocation(NpcLocation location, Collection<Player> viewers) {
-        super.setLocation(location.withY(location.getY() + 2.05), viewers);
+    public void setLocation(NpcLocation location) {
+        super.setLocation(location.withY(location.getY() + 2.05));
     }
 
     public static boolean ensureValidItemInput(String in) {

--- a/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramLine.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramLine.java
@@ -7,10 +7,10 @@ import lol.pyr.znpcsplus.api.entity.PropertyHolder;
 import lol.pyr.znpcsplus.entity.PacketEntity;
 import lol.pyr.znpcsplus.packets.PacketFactory;
 import lol.pyr.znpcsplus.util.NpcLocation;
+import lol.pyr.znpcsplus.util.Viewable;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -19,9 +19,9 @@ public class HologramLine<M> implements PropertyHolder {
     private final PacketEntity entity;
     private final Set<EntityProperty<?>> properties;
 
-    public HologramLine(M value, PacketFactory packetFactory, EntityType type, NpcLocation location) {
+    public HologramLine(Viewable viewable, M value, PacketFactory packetFactory, EntityType type, NpcLocation location) {
         this.value = value;
-        this.entity = new PacketEntity(packetFactory, this, type, location);
+        this.entity = new PacketEntity(packetFactory, this, viewable, type, location);
         this.properties = new HashSet<>();
     }
 
@@ -45,8 +45,8 @@ public class HologramLine<M> implements PropertyHolder {
         entity.despawn(player);
     }
 
-    public void setLocation(NpcLocation location, Collection<Player> viewers) {
-        entity.setLocation(location, viewers);
+    public void setLocation(NpcLocation location) {
+        entity.setLocation(location);
     }
 
     public int getEntityId() {

--- a/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramText.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramText.java
@@ -5,6 +5,7 @@ import lol.pyr.znpcsplus.api.entity.EntityProperty;
 import lol.pyr.znpcsplus.entity.EntityPropertyRegistryImpl;
 import lol.pyr.znpcsplus.packets.PacketFactory;
 import lol.pyr.znpcsplus.util.NpcLocation;
+import lol.pyr.znpcsplus.util.Viewable;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 
@@ -12,8 +13,8 @@ public class HologramText extends HologramLine<Component> {
 
     private static final Component BLANK  = Component.text("%blank%");
 
-    public HologramText(EntityPropertyRegistryImpl propertyRegistry, PacketFactory packetFactory, NpcLocation location, Component text) {
-        super(text, packetFactory, EntityTypes.ARMOR_STAND, location);
+    public HologramText(Viewable viewable,  EntityPropertyRegistryImpl propertyRegistry, PacketFactory packetFactory, NpcLocation location, Component text) {
+        super(viewable, text, packetFactory, EntityTypes.ARMOR_STAND, location);
         addProperty(propertyRegistry.getByName("name"));
         addProperty(propertyRegistry.getByName("invisible"));
     }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcImpl.java
@@ -48,14 +48,14 @@ public class NpcImpl extends Viewable implements Npc {
         this.type = type;
         this.location = location;
         this.uuid = uuid;
-        entity = new PacketEntity(packetFactory, this, type.getType(), location);
+        entity = new PacketEntity(packetFactory, this, this, type.getType(), location);
         hologram = new HologramImpl(propertyRegistry, configManager, packetFactory, textSerializer, location.withY(location.getY() + type.getHologramOffset()));
     }
 
     public void setType(NpcTypeImpl type) {
         UNSAFE_hideAll();
         this.type = type;
-        entity = new PacketEntity(packetFactory, this, type.getType(), entity.getLocation());
+        entity = new PacketEntity(packetFactory, this, this, type.getType(), entity.getLocation());
         hologram.setLocation(location.withY(location.getY() + type.getHologramOffset()));
         UNSAFE_showAll();
     }
@@ -85,11 +85,7 @@ public class NpcImpl extends Viewable implements Npc {
 
     public void setLocation(NpcLocation location) {
         this.location = location;
-        entity.setLocation(location, getViewers());
-        if (entity.hasMetadata("ridingVehicle")) {
-            PacketEntity armorStand = (PacketEntity) entity.getMetadata("ridingVehicle");
-            armorStand.setLocation(location.withY(location.getY() - 0.9), getViewers());
-        }
+        entity.setLocation(location);
         hologram.setLocation(location.withY(location.getY() + type.getHologramOffset()));
     }
 

--- a/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcImpl.java
@@ -86,6 +86,10 @@ public class NpcImpl extends Viewable implements Npc {
     public void setLocation(NpcLocation location) {
         this.location = location;
         entity.setLocation(location, getViewers());
+        if (entity.hasMetadata("ridingVehicle")) {
+            PacketEntity armorStand = (PacketEntity) entity.getMetadata("ridingVehicle");
+            armorStand.setLocation(location.withY(location.getY() - 0.9), getViewers());
+        }
         hologram.setLocation(location.withY(location.getY() + type.getHologramOffset()));
     }
 

--- a/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeImpl.java
@@ -118,7 +118,7 @@ public class NpcTypeImpl implements NpcType {
                     "potion_color", "potion_ambient", "display_name", "permission_required",
                     "player_knockback", "player_knockback_exempt_permission", "player_knockback_distance", "player_knockback_vertical",
                     "player_knockback_horizontal", "player_knockback_cooldown", "player_knockback_sound", "player_knockback_sound_name",
-                    "player_knockback_sound_volume", "player_knockback_sound_pitch", "entity_sitting");
+                    "player_knockback_sound_volume", "player_knockback_sound_pitch");
             if (!type.equals(EntityTypes.PLAYER)) addProperties("dinnerbone");
             // TODO: make this look nicer after completing the rest of the properties
             if (version.isNewerThanOrEquals(ServerVersion.V_1_9)) addProperties("glow");

--- a/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeImpl.java
@@ -176,6 +176,11 @@ public class NpcTypeImpl implements NpcType {
                     addProperties("wolf_variant");
                 }
             }
+            if (version.isNewerThanOrEquals(ServerVersion.V_1_21_4)) {
+                if (EntityTypes.isTypeInstanceOf(type, EntityTypes.CREAKING)) {
+                    addProperties("creaking_crumbling");
+                }
+            }
             return new NpcTypeImpl(name, type, hologramOffset, new HashSet<>(allowedProperties), defaultProperties);
         }
     }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeImpl.java
@@ -118,7 +118,7 @@ public class NpcTypeImpl implements NpcType {
                     "potion_color", "potion_ambient", "display_name", "permission_required",
                     "player_knockback", "player_knockback_exempt_permission", "player_knockback_distance", "player_knockback_vertical",
                     "player_knockback_horizontal", "player_knockback_cooldown", "player_knockback_sound", "player_knockback_sound_name",
-                    "player_knockback_sound_volume", "player_knockback_sound_pitch");
+                    "player_knockback_sound_volume", "player_knockback_sound_pitch", "entity_sitting");
             if (!type.equals(EntityTypes.PLAYER)) addProperties("dinnerbone");
             // TODO: make this look nicer after completing the rest of the properties
             if (version.isNewerThanOrEquals(ServerVersion.V_1_9)) addProperties("glow");

--- a/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeRegistryImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeRegistryImpl.java
@@ -82,7 +82,7 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
 
         register(builder(p, "enderman", EntityTypes.ENDERMAN)
                 .setHologramOffset(0.925)
-                .addProperties("enderman_held_block", "enderman_screaming", "enderman_staring"));
+                .addProperties("enderman_held_block", "enderman_screaming", "enderman_staring", "entity_sitting"));
 
         register(builder(p, "endermite", EntityTypes.ENDERMITE)
                 .setHologramOffset(-1.675));
@@ -93,7 +93,8 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
 
         register(builder(p, "giant", EntityTypes.GIANT)
                 .setHologramOffset(10.025)
-                .addEquipmentProperties());
+                .addEquipmentProperties()
+                .addProperties("entity_sitting"));
 
         register(builder(p, "guardian", EntityTypes.GUARDIAN)
                 .setHologramOffset(-1.125)
@@ -133,7 +134,8 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
 
         register(builder(p, "skeleton", EntityTypes.SKELETON)
                 .setHologramOffset(0.015)
-                .addEquipmentProperties());
+                .addEquipmentProperties()
+                .addProperties("entity_sitting"));
 
         register(builder(p, "skeleton_horse", EntityTypes.SKELETON_HORSE)
                 .setHologramOffset(-0.375));
@@ -169,14 +171,16 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
 
         register(builder(p, "zombie", EntityTypes.ZOMBIE)
                 .setHologramOffset(-0.025)
-                .addEquipmentProperties());
+                .addEquipmentProperties()
+                .addProperties("entity_sitting"));
 
         register(builder(p, "zombie_horse", EntityTypes.ZOMBIE_HORSE)
                 .setHologramOffset(-0.375));
 
         register(builder(p, "zombified_piglin", EntityTypes.ZOMBIFIED_PIGLIN)
                 .setHologramOffset(-0.025)
-                .addEquipmentProperties());
+                .addEquipmentProperties()
+                .addProperties("entity_sitting"));
 
         if (!version.isNewerThanOrEquals(ServerVersion.V_1_9)) return;
 
@@ -203,14 +207,17 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
 
         register(builder(p, "husk", EntityTypes.HUSK)
                 .setHologramOffset(-0.025)
-                .addEquipmentProperties());
+                .addEquipmentProperties()
+                .addProperties("entity_sitting"));
 
         register(builder(p, "stray", EntityTypes.STRAY)
                 .setHologramOffset(0.015)
-                .addEquipmentProperties());
+                .addEquipmentProperties()
+                .addProperties("entity_sitting"));
 
         register(builder(p, "evoker", EntityTypes.EVOKER)
-                .setHologramOffset(-0.025));
+                .setHologramOffset(-0.025)
+                .addProperties("entity_sitting"));
 
         register(builder(p, "llama", EntityTypes.LLAMA)
                 .setHologramOffset(-0.105)
@@ -222,20 +229,23 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
 
         register(builder(p, "vindicator", EntityTypes.VINDICATOR)
                 .setHologramOffset(-0.025)
-                .addProperties("celebrating"));
+                .addProperties("celebrating", "entity_sitting"));
 
         register(builder(p, "wither_skeleton", EntityTypes.WITHER_SKELETON)
                 .setHologramOffset(0.425)
-                .addEquipmentProperties());
+                .addEquipmentProperties()
+                .addProperties("entity_sitting"));
 
         register(builder(p, "zombie_villager", EntityTypes.ZOMBIE_VILLAGER)
                 .setHologramOffset(-0.025)
-                .addEquipmentProperties());
+                .addEquipmentProperties()
+                .addProperties("entity_sitting"));
 
         if (!version.isNewerThanOrEquals(ServerVersion.V_1_12)) return;
 
         register(builder(p, "illusioner", EntityTypes.ILLUSIONER)
-                .setHologramOffset(-0.025));
+                .setHologramOffset(-0.025)
+                .addProperties("entity_sitting"));
 
         register(builder(p, "parrot", EntityTypes.PARROT)
                 .setHologramOffset(-1.075)
@@ -252,7 +262,8 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
 
         register(builder(p, "drowned", EntityTypes.DROWNED)
                 .setHologramOffset(-0.025)
-                .addEquipmentProperties());
+                .addEquipmentProperties()
+                .addProperties("entity_sitting"));
 
         register(builder(p, "phantom", EntityTypes.PHANTOM)
                 .setHologramOffset(-1.475));
@@ -288,7 +299,7 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
         register(builder(p, "pillager", EntityTypes.PILLAGER)
                 .setHologramOffset(-0.025)
                 .addHandProperties()
-                .addProperties("pillager_charging"));
+                .addProperties("pillager_charging", "entity_sitting"));
 
         register(builder(p, "ravager", EntityTypes.RAVAGER)
                 .setHologramOffset(0.225));
@@ -316,11 +327,12 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
         register(builder(p, "piglin", EntityTypes.PIGLIN)
                 .setHologramOffset(-0.025)
                 .addEquipmentProperties()
-                .addProperties("piglin_baby", "piglin_charging_crossbow", "piglin_dancing"));
+                .addProperties("piglin_baby", "piglin_charging_crossbow", "piglin_dancing", "entity_sitting"));
 
         register(builder(p, "piglin_brute", EntityTypes.PIGLIN_BRUTE)
                 .setHologramOffset(-0.025)
-                .addEquipmentProperties());
+                .addEquipmentProperties()
+                .addProperties("entity_sitting"));
 
         register(builder(p, "strider", EntityTypes.STRIDER)
                 .setHologramOffset(-0.275)
@@ -379,7 +391,7 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
 
         register(builder(p, "bogged", EntityTypes.BOGGED)
                 .setHologramOffset(0.015)
-                .addProperties("bogged_sheared"));
+                .addProperties("bogged_sheared", "entity_sitting"));
 
         register(builder(p, "breeze", EntityTypes.BREEZE)
                 .setHologramOffset(-0.205));
@@ -388,7 +400,7 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
 
         register(builder(p, "creaking", EntityTypes.CREAKING)
                 .setHologramOffset(0.725)
-                .addProperties("creaking_active"));
+                .addProperties("creaking_active", "entity_sitting"));
     }
 
     public Collection<NpcType> getAll() {

--- a/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeRegistryImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeRegistryImpl.java
@@ -386,6 +386,12 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
 
         register(builder(p, "breeze", EntityTypes.BREEZE)
                 .setHologramOffset(-0.205));
+
+        if (!version.isNewerThanOrEquals(ServerVersion.V_1_21_2)) return;
+
+        register(builder(p, "creaking", EntityTypes.CREAKING)
+                .setHologramOffset(0.725)
+                .addProperties("creaking_active"));
     }
 
     public Collection<NpcType> getAll() {

--- a/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeRegistryImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeRegistryImpl.java
@@ -36,7 +36,7 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
         register(builder(p, "player", EntityTypes.PLAYER)
                 .setHologramOffset(-0.15D)
                 .addEquipmentProperties()
-                .addProperties("skin_cape", "skin_jacket", "skin_left_sleeve", "skin_right_sleeve", "skin_left_leg", "skin_right_leg", "skin_hat", "shoulder_entity_left", "shoulder_entity_right", "force_body_rotation")
+                .addProperties("skin_cape", "skin_jacket", "skin_left_sleeve", "skin_right_sleeve", "skin_left_leg", "skin_right_leg", "skin_hat", "shoulder_entity_left", "shoulder_entity_right", "force_body_rotation", "entity_sitting")
                 .addDefaultProperty("skin_cape", true)
                 .addDefaultProperty("skin_jacket", true)
                 .addDefaultProperty("skin_left_sleeve", true)

--- a/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeRegistryImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeRegistryImpl.java
@@ -205,9 +205,6 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
                 .setHologramOffset(-0.025)
                 .addEquipmentProperties());
 
-        register(builder(p, "polar_bear", EntityTypes.POLAR_BEAR)
-                .setHologramOffset(-0.575));
-
         register(builder(p, "stray", EntityTypes.STRAY)
                 .setHologramOffset(0.015)
                 .addEquipmentProperties());

--- a/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeRegistryImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeRegistryImpl.java
@@ -400,7 +400,7 @@ public class NpcTypeRegistryImpl implements NpcTypeRegistry {
 
         register(builder(p, "creaking", EntityTypes.CREAKING)
                 .setHologramOffset(0.725)
-                .addProperties("creaking_active", "entity_sitting"));
+                .addProperties("creaking_active"));
     }
 
     public Collection<NpcType> getAll() {

--- a/plugin/src/main/java/lol/pyr/znpcsplus/packets/PacketFactory.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/packets/PacketFactory.java
@@ -24,4 +24,5 @@ public interface PacketFactory {
     void sendMetadata(Player player, PacketEntity entity, List<EntityData> data);
     void sendHeadRotation(Player player, PacketEntity entity, float yaw, float pitch);
     void sendHandSwing(Player player, PacketEntity entity, boolean offHand);
+    void setPassenger(Player player, PacketEntity vehicle, PacketEntity passenger);
 }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/packets/V1_8PacketFactory.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/packets/V1_8PacketFactory.java
@@ -153,6 +153,12 @@ public class V1_8PacketFactory implements PacketFactory {
         sendPacket(player, new WrapperPlayServerEntityEquipment(entity.getEntityId(), Collections.singletonList(equipment)));
     }
 
+    @Override
+    public void setPassenger(Player player, PacketEntity vehicle, PacketEntity passenger) {
+        sendPacket(player, new WrapperPlayServerSetPassengers(vehicle.getEntityId(),
+                passenger == null ? new int[] {} : new int[] {passenger.getEntityId()}));
+    }
+
     protected void sendPacket(Player player, PacketWrapper<?> packet) {
         packetEvents.getPlayerManager().sendPacket(player, packet);
     }


### PR DESCRIPTION
## Commit Summary

- Added `entity_sitting` property to allow players and some other entities to sit.
- Bumped `PacketEvents` version to `2.7.0`.
- Added `creaking` NPC type.
- Added `creaking_active` and `creaking_crumbling` properties for `creaking`.
- Fixed multiple registrations of `polar_bear` NPC type.