### PR TITLE
Support for legacy section symbols in holograms

### DIFF
--- a/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/hologram/HologramImpl.java
@@ -48,7 +48,8 @@ public class HologramImpl extends Viewable implements Hologram {
     }
 
     public void addTextLine(String line) {
-        addTextLineComponent(textSerializer.deserialize(textSerializer.serialize(MiniMessage.miniMessage().deserialize(line))));
+        Component component = line.contains("§") ? Component.text(line) : MiniMessage.miniMessage().deserialize(line);
+        addTextLineComponent(textSerializer.deserialize(textSerializer.serialize(component)));
     }
 
     public void addItemLineStack(org.bukkit.inventory.ItemStack item) {


### PR DESCRIPTION
When importing from other plugins such as Citizens for example, they use the legacy section symbol (`§`) and the holograms within this plugin do not support that. This PR makes it so if a hologram line contains that legacy section symbol, it will simply invoke Component#text on the line, rather than using MiniMessage#miniMessage#deserialize.