### PR TITLE
Fix hologram text serialization for 1.8

### DIFF
--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/properties/NameProperty.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/properties/NameProperty.java
@@ -2,7 +2,6 @@ package lol.pyr.znpcsplus.entity.properties;
 
 import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
 import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
-import com.github.retrooper.packetevents.util.adventure.AdventureSerializer;
 import lol.pyr.znpcsplus.entity.EntityPropertyImpl;
 import lol.pyr.znpcsplus.entity.PacketEntity;
 import lol.pyr.znpcsplus.util.PapiUtil;
@@ -31,9 +30,7 @@ public class NameProperty extends EntityPropertyImpl<Component> {
         Component value = entity.getProperty(this);
         if (value != null) {
             value = PapiUtil.set(legacySerializer, player, value);
-            if (legacySerialization) {
-                properties.put(2, newEntityData(2, EntityDataTypes.STRING, AdventureSerializer.serializer().asJson(value)));
-            } else if (optional) {
+            if (optional) {
                 properties.put(2, newEntityData(2, EntityDataTypes.OPTIONAL_ADV_COMPONENT, Optional.of(value)));
             } else {
                 properties.put(2, newEntityData(2, EntityDataTypes.STRING, LegacyComponentSerializer.legacySection().serialize(value)));


### PR DESCRIPTION
Hologram text was displaying as raw JSON strings in Minecraft 1.8 and earlier versions. This occurred because the legacy serialization path was using AdventureSerializer.asJson() which output JSON format that older clients couldn't properly parse.