### PR TITLE
add support to 1.21.11

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -8,7 +8,7 @@ runServer {
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(21)
     }
-    minecraftVersion "1.21.10"
+    minecraftVersion "1.21.11"
 }
 
 processResources {
@@ -19,7 +19,7 @@ dependencies {
     compileOnly "me.clip:placeholderapi:2.11.6" // Placeholder support
     implementation "com.google.code.gson:gson:2.10.1" // JSON parsing
     implementation "org.bstats:bstats-bukkit:3.0.2" // Plugin stats
-    implementation "com.github.retrooper:packetevents-spigot:2.10.0" // Packets
+    implementation "com.github.retrooper:packetevents-spigot:2.11.1" // Packets
     implementation "space.arim.dazzleconf:dazzleconf-ext-snakeyaml:1.2.1" // Configs
     implementation "lol.pyr:director-adventure:2.1.2" // Commands
 


### PR DESCRIPTION
This pull request updates the Minecraft version and the PacketEvents dependency version in the `plugin/build.gradle` file to keep the project up to date with the latest releases.

Dependency and version updates:

* Updated the `minecraftVersion` in the `runServer` block from `1.21.10` to `1.21.11` to support the latest Minecraft server version.
* Updated the `packetevents-spigot` dependency from version `2.10.0` to `2.11.1` for improved packet handling and compatibility.