### PR TITLE
feat: add NPC scale support for Minecraft 1.20.5+

### DIFF
--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/EntityPropertyRegistryImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/EntityPropertyRegistryImpl.java
@@ -720,6 +720,10 @@ public class EntityPropertyRegistryImpl implements EntityPropertyRegistry {
         register(new CustomTypeProperty<>("sniffer_state", 17, SnifferState.IDLING, EntityDataTypes.SNIFFER_STATE, state -> com.github.retrooper.packetevents.protocol.entity.sniffer.SnifferState.valueOf(state.name())));
 
         if (!ver.isNewerThanOrEquals(ServerVersion.V_1_20_5)) return;
+
+        // Attribute Scale
+        register(new AttributeProperty(packetFactory, "scale", Attributes.SCALE));
+
         // Armadillo
         register(new CustomTypeProperty<>("armadillo_state", 17, ArmadilloState.IDLE, EntityDataTypes.ARMADILLO_STATE, state ->
                 com.github.retrooper.packetevents.protocol.entity.armadillo.ArmadilloState.valueOf(state.name())));

--- a/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeImpl.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/npc/NpcTypeImpl.java
@@ -122,6 +122,9 @@ public class NpcTypeImpl implements NpcType {
             if (!type.equals(EntityTypes.PLAYER)) addProperties("dinnerbone");
             if (EntityTypes.isTypeInstanceOf(type, EntityTypes.LIVINGENTITY)) {
                 addProperties("health", "attribute_max_health");
+                if (version.isNewerThanOrEquals(ServerVersion.V_1_20_5)) {
+                    addProperties("scale");
+                }
             }
             // TODO: make this look nicer after completing the rest of the properties
             if (version.isNewerThanOrEquals(ServerVersion.V_1_9)) addProperties("glow");


### PR DESCRIPTION
- Registered new AttributeProperty "scale" in EntityPropertyRegistryImpl
- Only active for versions 1.20.5 and above