### PR TITLE
Fix & Upgrade

### DIFF
--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/PacketEntity.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/PacketEntity.java
@@ -32,9 +32,8 @@ public class PacketEntity implements PropertyHolder {
     private PacketEntity vehicle;
     private Integer vehicleId;
     private List<Integer> passengers;
-    // private boolean listedInTabList = true;
 
-    private final Set<Player> listedInTabList = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Set<Player> listedInTabList = ConcurrentHashMap.newKeySet();
 
     public PacketEntity(PacketFactory packetFactory, PropertyHolder properties, Viewable viewable, EntityType type, NpcLocation location) {
         this.packetFactory = packetFactory;

--- a/plugin/src/main/java/lol/pyr/znpcsplus/entity/PacketEntity.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/entity/PacketEntity.java
@@ -16,6 +16,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class PacketEntity implements PropertyHolder {
     private final PacketFactory packetFactory;
@@ -31,7 +32,9 @@ public class PacketEntity implements PropertyHolder {
     private PacketEntity vehicle;
     private Integer vehicleId;
     private List<Integer> passengers;
-    private boolean listedInTabList = true;
+    // private boolean listedInTabList = true;
+
+    private final Set<Player> listedInTabList = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     public PacketEntity(PacketFactory packetFactory, PropertyHolder properties, Viewable viewable, EntityType type, NpcLocation location) {
         this.packetFactory = packetFactory;
@@ -227,11 +230,15 @@ public class PacketEntity implements PropertyHolder {
         return properties.getAppliedProperties();
     }
 
-    public boolean isListedInTabList() {
-        return listedInTabList;
+    public boolean isListedInTabList(Player player) {
+        return this.listedInTabList.contains(player);
     }
 
-    public void setListedInTabList(boolean listedInTabList) {
-        this.listedInTabList = listedInTabList;
+    public void setListedInTab(Player player) {
+        listedInTabList.add(player);
+    }
+
+    public void setUnlistedInTab(Player player) {
+        listedInTabList.remove(player);
     }
 }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/packets/V1_19_3PacketFactory.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/packets/V1_19_3PacketFactory.java
@@ -45,7 +45,11 @@ public class V1_19_3PacketFactory extends V1_17PacketFactory {
             sendPacket(player, new WrapperPlayServerPlayerInfoUpdate(EnumSet.of(WrapperPlayServerPlayerInfoUpdate.Action.ADD_PLAYER,
                     WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LISTED, WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_DISPLAY_NAME),
                     info, info, info));
-            entity.setListedInTabList(true);
+
+            if (listed) {
+                entity.setListedInTab(player);
+            }
+
             future.complete(null);
         });
         return future;
@@ -54,9 +58,9 @@ public class V1_19_3PacketFactory extends V1_17PacketFactory {
     @Override
     public void removeTabPlayer(Player player, PacketEntity entity) {
         if (entity.getType() != EntityTypes.PLAYER) return;
-        if (!entity.isListedInTabList()) return;
+        if (!entity.isListedInTabList(player)) return;
         sendPacket(player, new WrapperPlayServerPlayerInfoRemove(entity.getUuid()));
-        entity.setListedInTabList(false);
+        entity.setUnlistedInTab(player);
     }
 
     @Override
@@ -66,7 +70,12 @@ public class V1_19_3PacketFactory extends V1_17PacketFactory {
                 new WrapperPlayServerPlayerInfoUpdate.PlayerInfo(new UserProfile(entity.getUuid(), null),
                         listed, 1, GameMode.CREATIVE, null, null))
         );
-        entity.setListedInTabList(listed);
+
+        if (listed) {
+            entity.setListedInTab(player);
+        } else {
+            entity.setUnlistedInTab(player);
+        }
     }
 
     @Override
@@ -74,7 +83,7 @@ public class V1_19_3PacketFactory extends V1_17PacketFactory {
         if (entity.getType() != EntityTypes.PLAYER) return;
         sendPacket(player, new WrapperPlayServerPlayerInfoUpdate(WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_DISPLAY_NAME,
                 new WrapperPlayServerPlayerInfoUpdate.PlayerInfo(new UserProfile(entity.getUuid(), null),
-                        entity.isListedInTabList(), 1, GameMode.CREATIVE, displayName, null))
+                        entity.isListedInTabList(player), 1, GameMode.CREATIVE, displayName, null))
         );
     }
 }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/packets/V1_8PacketFactory.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/packets/V1_8PacketFactory.java
@@ -60,16 +60,28 @@ public class V1_8PacketFactory implements PacketFactory {
     @Override
     public CompletableFuture<Void> spawnPlayer(Player player, PacketEntity entity, PropertyHolder properties) {
         return addTabPlayer(player, entity, properties).thenAccept(ignored -> {
-            createTeam(player, entity, properties.getProperty(propertyRegistry.getByName("glow", NamedColor.class)));
+            NamedColor glowColor = properties.getProperty(propertyRegistry.getByName("glow", NamedColor.class));
+            createTeam(player, entity, glowColor);
+
             NpcLocation location = entity.getLocation();
-            sendPacket(player, new WrapperPlayServerSpawnPlayer(entity.getEntityId(),
-                    entity.getUuid(), npcLocationToVector(location), location.getYaw(), location.getPitch(), Collections.emptyList()));
-            //noinspection DuplicatedCode
+
+            sendPacket(player, new WrapperPlayServerSpawnPlayer(
+                    entity.getEntityId(),
+                    entity.getUuid(),
+                    npcLocationToVector(location),
+                    location.getYaw(),
+                    location.getPitch(),
+                    Collections.emptyList()
+            ));
+
             sendPacket(player, new WrapperPlayServerEntityHeadLook(entity.getEntityId(), location.getYaw()));
             sendAllMetadata(player, entity, properties);
             sendAllAttributes(player, entity, properties);
-            if (alwaysVisibleInTabProperty == null || !properties.getProperty(alwaysVisibleInTabProperty.get()))
+
+            Boolean alwaysVisible = properties.getProperty(alwaysVisibleInTabProperty.get());
+            if (alwaysVisible == null || !alwaysVisible) {
                 scheduler.runLaterAsync(() -> removeTabPlayer(player, entity), configManager.getConfig().tabHideDelay());
+            }
         });
     }
 
@@ -78,14 +90,46 @@ public class V1_8PacketFactory implements PacketFactory {
         NpcLocation location = entity.getLocation();
         EntityType type = entity.getType();
         ClientVersion clientVersion = packetEvents.getServerManager().getVersion().toClientVersion();
-        sendPacket(player, type.getLegacyId(clientVersion) == -1 ?
-                new WrapperPlayServerSpawnLivingEntity(entity.getEntityId(), entity.getUuid(), type, npcLocationToVector(location),
-                        location.getYaw(), location.getPitch(), location.getYaw(), new Vector3d(), Collections.emptyList()) :
-                new WrapperPlayServerSpawnEntity(entity.getEntityId(), Optional.of(entity.getUuid()), entity.getType(), npcLocationToVector(location),
-                        location.getPitch(), location.getYaw(), location.getYaw(), 0, Optional.empty()));
+
+        boolean hasLegacyId = type.getLegacyId(clientVersion) != -1;
+        sendPacket(player, hasLegacyId ? buildSpawnEntityPacket(entity, location) : buildSpawnLivingEntityPacket(entity, location));
+
         sendAllMetadata(player, entity, properties);
-        if (EntityTypes.isTypeInstanceOf(type, EntityTypes.LIVINGENTITY)) sendAllAttributes(player, entity, properties);
-        createTeam(player, entity, properties.getProperty(propertyRegistry.getByName("glow", NamedColor.class)));
+
+        if (EntityTypes.isTypeInstanceOf(type, EntityTypes.LIVINGENTITY)) {
+            sendAllAttributes(player, entity, properties);
+        }
+
+        NamedColor glowColor = properties.getProperty(propertyRegistry.getByName("glow", NamedColor.class));
+        createTeam(player, entity, glowColor);
+    }
+
+    private WrapperPlayServerSpawnLivingEntity buildSpawnLivingEntityPacket(PacketEntity entity, NpcLocation location) {
+        return new WrapperPlayServerSpawnLivingEntity(
+                entity.getEntityId(),
+                entity.getUuid(),
+                entity.getType(),
+                npcLocationToVector(location),
+                location.getYaw(),
+                location.getPitch(),
+                location.getYaw(),
+                new Vector3d(),
+                Collections.emptyList()
+        );
+    }
+
+    private WrapperPlayServerSpawnEntity buildSpawnEntityPacket(PacketEntity entity, NpcLocation location) {
+        return new WrapperPlayServerSpawnEntity(
+                entity.getEntityId(),
+                Optional.of(entity.getUuid()),
+                entity.getType(),
+                npcLocationToVector(location),
+                location.getPitch(),
+                location.getYaw(),
+                location.getYaw(),
+                0,
+                Optional.empty()
+        );
     }
 
     protected Vector3d npcLocationToVector(NpcLocation location) {
@@ -109,46 +153,80 @@ public class V1_8PacketFactory implements PacketFactory {
     @Override
     public CompletableFuture<Void> addTabPlayer(Player player, PacketEntity entity, PropertyHolder properties) {
         if (entity.getType() != EntityTypes.PLAYER) return CompletableFuture.completedFuture(null);
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        Component displayName = tabListDisplayNameProperty != null && properties.getProperty(tabListDisplayNameProperty.get()) != null ?
-                PapiUtil.set(textSerializer, player, properties.getProperty(tabListDisplayNameProperty.get())) :
-                Component.text(PapiUtil.set(player, configManager.getConfig().tabDisplayName()
-                        .replace("{id}", Integer.toString(entity.getEntityId()))
-                        .replace("{name}", displayNameProperty != null && properties.hasProperty(displayNameProperty.get()) ?
-                                properties.getProperty(displayNameProperty.get()) :
-                                "")
-                ));
-        skinned(player, properties, new UserProfile(entity.getUuid(), Integer.toString(entity.getEntityId()))).thenAccept(profile -> {
-            sendPacket(player, new WrapperPlayServerPlayerInfo(
-                    WrapperPlayServerPlayerInfo.Action.ADD_PLAYER, new WrapperPlayServerPlayerInfo.PlayerData(
-                            displayName, profile, GameMode.CREATIVE, 1)));
-            entity.setListedInTabList(true);
-            future.complete(null);
+
+        Component displayName = resolveDisplayName(player, entity, properties);
+        UserProfile profile = new UserProfile(entity.getUuid(), Integer.toString(entity.getEntityId()));
+
+        entity.setListedInTab(player);
+
+        return skinned(player, properties, profile).thenAccept(skinnedProfile -> {
+            if (!entity.isListedInTabList(player)) {
+                return;
+            }
+
+            WrapperPlayServerPlayerInfo.PlayerData playerData = new WrapperPlayServerPlayerInfo.PlayerData(
+                    displayName, skinnedProfile, GameMode.CREATIVE, 1);
+            sendPacket(player, new WrapperPlayServerPlayerInfo(WrapperPlayServerPlayerInfo.Action.ADD_PLAYER, playerData));
         });
-        return future;
+    }
+
+    private Component resolveDisplayName(Player player, PacketEntity entity, PropertyHolder properties) {
+        if (tabListDisplayNameProperty != null) {
+            Component tabDisplayName = properties.getProperty(tabListDisplayNameProperty.get());
+            if (tabDisplayName != null) return PapiUtil.set(textSerializer, player, tabDisplayName);
+        }
+
+        String name = displayNameProperty != null && properties.hasProperty(displayNameProperty.get())
+                ? properties.getProperty(displayNameProperty.get())
+                : "";
+
+        String displayNameText = configManager.getConfig().tabDisplayName()
+                .replace("{id}", Integer.toString(entity.getEntityId()))
+                .replace("{name}", name);
+
+        return Component.text(PapiUtil.set(player, displayNameText));
     }
 
     @Override
     public void removeTabPlayer(Player player, PacketEntity entity) {
-        if (entity.getType() != EntityTypes.PLAYER) return;
-        if (!entity.isListedInTabList()) return; // Already removed
+        if (entity.getType() != EntityTypes.PLAYER) {
+            return;
+        }
+
+        if (!entity.isListedInTabList(player)) {
+            return;
+        }
+
+        entity.setUnlistedInTab(player);
+
         sendPacket(player, new WrapperPlayServerPlayerInfo(
                 WrapperPlayServerPlayerInfo.Action.REMOVE_PLAYER, new WrapperPlayServerPlayerInfo.PlayerData(null,
                 new UserProfile(entity.getUuid(), null), null, -1)));
-        entity.setListedInTabList(false);
     }
 
     @Override
     public void createTeam(Player player, PacketEntity entity, NamedColor namedColor) {
-        sendPacket(player, new WrapperPlayServerTeams("npc_team_" + entity.getEntityId(), WrapperPlayServerTeams.TeamMode.CREATE, new WrapperPlayServerTeams.ScoreBoardTeamInfo(
-                Component.text(" "), null, null,
+        String teamName = "npc_team_" + entity.getEntityId();
+        NamedTextColor teamColor = namedColor == null
+                ? NamedTextColor.WHITE
+                : NamedTextColor.NAMES.value(namedColor.name().toLowerCase());
+
+        WrapperPlayServerTeams.ScoreBoardTeamInfo teamInfo = new WrapperPlayServerTeams.ScoreBoardTeamInfo(
+                Component.text(" "),
+                null,
+                null,
                 WrapperPlayServerTeams.NameTagVisibility.NEVER,
                 WrapperPlayServerTeams.CollisionRule.NEVER,
-                namedColor == null ? NamedTextColor.WHITE : NamedTextColor.NAMES.value(namedColor.name().toLowerCase()),
+                teamColor,
                 WrapperPlayServerTeams.OptionData.NONE
-        )));
-        sendPacket(player, new WrapperPlayServerTeams("npc_team_" + entity.getEntityId(), WrapperPlayServerTeams.TeamMode.ADD_ENTITIES, (WrapperPlayServerTeams.ScoreBoardTeamInfo) null,
-                entity.getType() == EntityTypes.PLAYER ? Integer.toString(entity.getEntityId()) : entity.getUuid().toString()));
+        );
+
+        String entityIdentifier = entity.getType() == EntityTypes.PLAYER
+                ? Integer.toString(entity.getEntityId())
+                : entity.getUuid().toString();
+
+        sendPacket(player, new WrapperPlayServerTeams(teamName, WrapperPlayServerTeams.TeamMode.CREATE, teamInfo));
+        sendPacket(player, new WrapperPlayServerTeams(teamName, WrapperPlayServerTeams.TeamMode.ADD_ENTITIES, (WrapperPlayServerTeams.ScoreBoardTeamInfo) null, entityIdentifier));
     }
 
     @Override
@@ -159,7 +237,8 @@ public class V1_8PacketFactory implements PacketFactory {
     @Override
     public void sendAllMetadata(Player player, PacketEntity entity, PropertyHolder properties) {
         Map<Integer, EntityData<?>> datas = new HashMap<>();
-        for (EntityProperty<?> property : properties.getAppliedProperties()) ((EntityPropertyImpl<?>) property).apply(player, entity, false, datas);
+        for (EntityProperty<?> property : properties.getAppliedProperties())
+            ((EntityPropertyImpl<?>) property).apply(player, entity, false, datas);
         sendMetadata(player, entity, new ArrayList<>(datas.values()));
     }
 
@@ -170,7 +249,7 @@ public class V1_8PacketFactory implements PacketFactory {
 
     @Override
     public void sendHeadRotation(Player player, PacketEntity entity, float yaw, float pitch) {
-        sendPacket(player, new WrapperPlayServerEntityHeadLook(entity.getEntityId(),yaw));
+        sendPacket(player, new WrapperPlayServerEntityHeadLook(entity.getEntityId(), yaw));
         sendPacket(player, new WrapperPlayServerEntityRotation(entity.getEntityId(), yaw, pitch, true));
     }
 
@@ -189,7 +268,8 @@ public class V1_8PacketFactory implements PacketFactory {
     }
 
     protected CompletableFuture<UserProfile> skinned(Player player, PropertyHolder properties, UserProfile profile) {
-        if (!properties.hasProperty(propertyRegistry.getByName("skin"))) return CompletableFuture.completedFuture(profile);
+        if (!properties.hasProperty(propertyRegistry.getByName("skin")))
+            return CompletableFuture.completedFuture(profile);
         BaseSkinDescriptor descriptor = (BaseSkinDescriptor) properties.getProperty(propertyRegistry.getByName("skin", SkinDescriptor.class));
         if (descriptor.supportsInstant(player)) {
             descriptor.fetchInstant(player).apply(profile);
@@ -232,9 +312,9 @@ public class V1_8PacketFactory implements PacketFactory {
     @Override
     public void updateListed(Player player, PacketEntity entity, boolean listed) {
         if (entity.getType() != EntityTypes.PLAYER) return;
-        if (listed && !entity.isListedInTabList()) {
+        if (listed && !entity.isListedInTabList(player)) {
             addTabPlayer(player, entity, entity.getProperties());
-        } else if (!listed && entity.isListedInTabList()) {
+        } else if (!listed && entity.isListedInTabList(player)) {
             removeTabPlayer(player, entity);
         }
     }
@@ -244,9 +324,9 @@ public class V1_8PacketFactory implements PacketFactory {
         if (entity.getType() != EntityTypes.PLAYER) return;
         sendPacket(player, new WrapperPlayServerPlayerInfo(
                 WrapperPlayServerPlayerInfo.Action.UPDATE_DISPLAY_NAME, new WrapperPlayServerPlayerInfo.PlayerData(
-                    displayName,
-                    new UserProfile(entity.getUuid(), null), null, -1
-                )
+                displayName,
+                new UserProfile(entity.getUuid(), null), null, -1
+        )
         ));
     }
 }

--- a/plugin/src/main/java/lol/pyr/znpcsplus/util/Viewable.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/util/Viewable.java
@@ -9,11 +9,18 @@ import java.util.concurrent.*;
 import java.util.stream.Collectors;
 
 public abstract class Viewable {
-    private final static List<WeakReference<Viewable>> all = Collections.synchronizedList(new ArrayList<>());
+    private static final List<WeakReference<Viewable>> all = Collections.synchronizedList(new ArrayList<>());
+    private static final ExecutorService visibilityExecutor = Executors.newSingleThreadExecutor();
+
+    private final Set<Player> viewers = ConcurrentHashMap.newKeySet();
+
+    public Viewable() {
+        all.add(new WeakReference<>(this));
+    }
 
     public static List<Viewable> all() {
         synchronized (all) {
-            all.removeIf(reference -> reference.get() == null);
+            all.removeIf(ref -> ref.get() == null);
             return all.stream()
                     .map(Reference::get)
                     .collect(Collectors.toList());
@@ -24,19 +31,12 @@ public abstract class Viewable {
         visibilityExecutor.shutdown();
     }
 
-    private final static ExecutorService visibilityExecutor = Executors.newSingleThreadExecutor();
-    private final Set<Player> viewers = ConcurrentHashMap.newKeySet();
-
-    public Viewable() {
-        all.add(new WeakReference<>(this));
-    }
-
     public void delete() {
         visibilityExecutor.submit(() -> {
             UNSAFE_hideAll();
             viewers.clear();
             synchronized (all) {
-                all.removeIf(reference -> reference.get() == null || reference.get() == this);
+                all.removeIf(ref -> ref.get() == null || ref.get() == this);
             }
         });
     }
@@ -45,14 +45,37 @@ public abstract class Viewable {
         CompletableFuture<Void> future = new CompletableFuture<>();
         visibilityExecutor.submit(() -> {
             UNSAFE_hideAll();
-            UNSAFE_showAll().thenRun(() -> future.complete(null));
+            UNSAFE_showAll()
+                    .whenComplete((v, ex) -> {
+                        if (ex != null) future.completeExceptionally(ex);
+                        else future.complete(null);
+                    });
         });
         return future;
     }
 
     public CompletableFuture<Void> respawn(Player player) {
-        hide(player);
-        return show(player);
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        visibilityExecutor.submit(() -> {
+            if (!viewers.contains(player)) {
+                // Not visible — just show
+                viewers.add(player);
+                UNSAFE_show(player)
+                        .whenComplete((v, ex) -> {
+                            if (ex != null) future.completeExceptionally(ex);
+                            else future.complete(null);
+                        });
+                return;
+            }
+            viewers.remove(player);
+            // Wait for hide to fully complete, THEN show
+            UNSAFE_hideAndShow(player)
+                    .whenComplete((v, ex) -> {
+                        if (ex != null) future.completeExceptionally(ex);
+                        else future.complete(null);
+                    });
+        });
+        return future;
     }
 
     public CompletableFuture<Void> show(Player player) {
@@ -63,15 +86,18 @@ public abstract class Viewable {
                 return;
             }
             viewers.add(player);
-            UNSAFE_show(player).thenRun(() -> future.complete(null));
+            UNSAFE_show(player)
+                    .whenComplete((v, ex) -> {
+                        if (ex != null) future.completeExceptionally(ex);
+                        else future.complete(null);
+                    });
         });
         return future;
     }
 
     public void hide(Player player) {
         visibilityExecutor.submit(() -> {
-            if (!viewers.contains(player)) return;
-            viewers.remove(player);
+            if (!viewers.remove(player)) return;
             UNSAFE_hide(player);
         });
     }
@@ -80,22 +106,29 @@ public abstract class Viewable {
         viewers.remove(player);
     }
 
-    protected void UNSAFE_hideAll() {
-        for (Player viewer : viewers) UNSAFE_hide(viewer);
-    }
-
-    protected CompletableFuture<Void> UNSAFE_showAll() {
-        return FutureUtil.allOf(viewers.stream()
-                .map(this::UNSAFE_show)
-                .collect(Collectors.toList()));
-    }
-
     public Set<Player> getViewers() {
         return Collections.unmodifiableSet(viewers);
     }
 
     public boolean isVisibleTo(Player player) {
         return viewers.contains(player);
+    }
+
+    protected void UNSAFE_hideAll() {
+        viewers.forEach(this::UNSAFE_hide);
+    }
+
+    protected CompletableFuture<Void> UNSAFE_showAll() {
+        List<CompletableFuture<?>> futures = viewers.stream()
+                .map(this::UNSAFE_show)
+                .collect(Collectors.toList());
+        return FutureUtil.allOf(futures);
+    }
+
+    protected CompletableFuture<Void> UNSAFE_hideAndShow(Player player) {
+        UNSAFE_hide(player);
+        viewers.add(player);
+        return UNSAFE_show(player);
     }
 
     protected abstract CompletableFuture<Void> UNSAFE_show(Player player);


### PR DESCRIPTION
I discovered an issue: when other players are near an NPC, the NPC names sometimes get stuck at the top of the tab list. The cause turned out to be in the classes `lol.pyr.znpcsplus.entity.PacketEntity` and `PacketFactory`.

`PacketEntity` has a field called `listedInTabList`, which is handled in `PacketFactory` as if each player had their own instance of `PacketEntity`. In reality, that’s not the case, and this mismatch is what caused the bug. I fixed it by adding a `Set` of players inside `PacketEntity` and tracking the state separately for each player.

While investigating the issue, I also refactored the `Viewable` class and fixed several potential problems. At first, it seemed like the issue was caused by a double method call there, but that turned out to be only a side effect.