### PR TITLE
Add timeouts and custom executor for async URL requests

### DIFF
--- a/plugin/src/main/java/lol/pyr/znpcsplus/ZNpcsPlus.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/ZNpcsPlus.java
@@ -125,6 +125,7 @@ public class ZNpcsPlus {
         TaskScheduler scheduler = FoliaUtil.isFolia() ? new FoliaScheduler(bootstrap) : new SpigotScheduler(bootstrap);
         shutdownTasks.add(scheduler::cancelAll);
         shutdownTasks.add(Viewable::shutdownExecutor);
+        shutdownTasks.add(FutureUtil::shutdownExecutor);
 
         PacketFactory packetFactory = setupPacketFactory(scheduler, propertyRegistry, configManager);
         propertyRegistry.registerTypes(packetFactory, textSerializer, scheduler);

--- a/plugin/src/main/java/lol/pyr/znpcsplus/skin/cache/MojangSkinCache.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/skin/cache/MojangSkinCache.java
@@ -52,6 +52,8 @@ public class MojangSkinCache {
             HttpURLConnection connection = null;
             try {
                 connection = (HttpURLConnection) url.openConnection();
+                connection.setReadTimeout(10000);
+                connection.setConnectTimeout(15000);
                 connection.setRequestMethod("GET");
                 try (Reader reader = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8)) {
                     JsonObject obj = JsonParser.parseReader(reader).getAsJsonObject();
@@ -85,6 +87,8 @@ public class MojangSkinCache {
             HttpURLConnection connection = null;
             try {
                 connection = (HttpURLConnection) url.openConnection();
+                connection.setReadTimeout(10000);
+                connection.setConnectTimeout(15000);
                 connection.setRequestMethod("GET");
                 try (Reader reader = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8)) {
                     JsonObject obj = JsonParser.parseReader(reader).getAsJsonObject();
@@ -116,6 +120,8 @@ public class MojangSkinCache {
             HttpURLConnection connection = null;
             try {
                 connection = (HttpURLConnection) apiUrl.openConnection();
+                connection.setReadTimeout(10000);
+                connection.setConnectTimeout(15000);
                 connection.setRequestMethod("POST");
                 connection.setRequestProperty("accept", "application/json");
                 connection.setRequestProperty("Content-Type", "application/json");
@@ -232,6 +238,8 @@ public class MojangSkinCache {
             HttpURLConnection connection = null;
             try {
                 connection = (HttpURLConnection) url.openConnection();
+                connection.setReadTimeout(10000);
+                connection.setConnectTimeout(15000);
                 connection.setRequestMethod("GET");
                 try (Reader reader = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8)) {
                     JsonObject obj = JsonParser.parseReader(reader).getAsJsonObject();

--- a/plugin/src/main/java/lol/pyr/znpcsplus/skin/cache/MojangSkinCache.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/skin/cache/MojangSkinCache.java
@@ -156,7 +156,7 @@ public class MojangSkinCache {
     public CompletableFuture<SkinImpl> fetchFromFile(String path) throws FileNotFoundException {
         File file = new File(skinsFolder, path);
         if (!file.exists()) throw new FileNotFoundException("File not found: " + path);
-        return CompletableFuture.supplyAsync(() -> {
+        return FutureUtil.exceptionPrintingSupplyAsync(() -> {
             URL apiUrl = parseUrl("https://api.mineskin.org/generate/upload");
             HttpURLConnection connection = null;
             try {

--- a/plugin/src/main/java/lol/pyr/znpcsplus/skin/descriptor/PrefetchedDescriptor.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/skin/descriptor/PrefetchedDescriptor.java
@@ -28,7 +28,7 @@ public class PrefetchedDescriptor implements BaseSkinDescriptor, SkinDescriptor 
     }
 
     public static CompletableFuture<PrefetchedDescriptor> fromFile(MojangSkinCache cache, String path) {
-        return CompletableFuture.supplyAsync(() -> {
+        return FutureUtil.exceptionPrintingSupplyAsync(() -> {
             try {
                 return new PrefetchedDescriptor(cache.fetchFromFile(path).join());
             } catch (FileNotFoundException e) {

--- a/plugin/src/main/java/lol/pyr/znpcsplus/util/FutureUtil.java
+++ b/plugin/src/main/java/lol/pyr/znpcsplus/util/FutureUtil.java
@@ -2,9 +2,13 @@ package lol.pyr.znpcsplus.util;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 public class FutureUtil {
+    private static final ExecutorService executor = Executors.newCachedThreadPool();
+
     public static CompletableFuture<Void> allOf(Collection<CompletableFuture<?>> futures) {
         return exceptionPrintingRunAsync(() -> {
             for (CompletableFuture<?> future : futures) future.join();
@@ -19,16 +23,20 @@ public class FutureUtil {
     }
 
     public static CompletableFuture<Void> exceptionPrintingRunAsync(Runnable runnable) {
-        return CompletableFuture.runAsync(runnable).exceptionally(throwable -> {
+        return CompletableFuture.runAsync(runnable, executor).exceptionally(throwable -> {
             throwable.printStackTrace();
             return null;
         });
     }
 
     public static <T> CompletableFuture<T> exceptionPrintingSupplyAsync(Supplier<T> supplier) {
-        return CompletableFuture.supplyAsync(supplier).exceptionally(throwable -> {
+        return CompletableFuture.supplyAsync(supplier, executor).exceptionally(throwable -> {
             throwable.printStackTrace();
             return null;
         });
+    }
+
+    public static void shutdownExecutor() {
+        executor.shutdownNow();
     }
 }


### PR DESCRIPTION
Runtime URL requests were using Java's default `ForkJoinPool.commonPool()` through `CompletableFuture`. Since the common pool is shared across the whole JVM, blocking network operations can occupy shared worker threads and affect unrelated async tasks.
Some URL requests also had no explicit timeouts, so calls to external services could potentially block for too long.
